### PR TITLE
compact-constants: fold constants into one per partial round

### DIFF
--- a/src/poseidon/primitives.rs
+++ b/src/poseidon/primitives.rs
@@ -24,6 +24,8 @@ pub(crate) mod pasta;
 //pub(crate) mod test_vectors;
 
 mod p128pow5t3;
+mod p128pow5t3_compact;
+
 pub use p128pow5t3::P128Pow5T3;
 
 use grain::SboxType;

--- a/src/poseidon/primitives/p128pow5t3_compact.rs
+++ b/src/poseidon/primitives/p128pow5t3_compact.rs
@@ -1,0 +1,82 @@
+use std::marker::PhantomData;
+
+use halo2_proofs::arithmetic::FieldExt;
+
+use super::p128pow5t3::P128Pow5T3Constants;
+use super::{Mds, Spec};
+
+/// Poseidon-128 using the $x^5$ S-box, with a width of 3 field elements, and the
+/// standard number of rounds for 128-bit security "with margin".
+///
+#[derive(Debug)]
+pub struct P128Pow5T3CompactSpec<Fp> {
+    _marker: PhantomData<Fp>,
+}
+
+impl<Fp: P128Pow5T3Constants> Spec<Fp, 3, 2> for P128Pow5T3CompactSpec<Fp> {
+    fn full_rounds() -> usize {
+        8
+    }
+
+    fn partial_rounds() -> usize {
+        Fp::partial_rounds()
+    }
+
+    fn sbox(val: Fp) -> Fp {
+        val.pow_vartime(&[5])
+    }
+
+    fn secure_mds() -> usize {
+        unimplemented!()
+    }
+
+    fn constants() -> (Vec<[Fp; 3]>, Mds<Fp, 3>, Mds<Fp, 3>) {
+        let (mut rc, mds, inv) = (Fp::round_constants(), Fp::mds(), Fp::mds_inv());
+
+        let first_partial = Self::full_rounds() / 2;
+        let after_partials = first_partial + Self::partial_rounds();
+
+        // Propagate the constants of each partial round into the next.
+        for i in first_partial..after_partials {
+            // Extract the constants rc[i][1] and rc[i][2] that do not pass through the S-box.
+            // Leave the value 0 in their place.
+            // rc[i][0] stays in place.
+            let rc_tail = vec_remove_tail(&mut rc[i]);
+
+            // Pass forward through the MDS matrix.
+            let rc_carry = mat_mul(&mds, &rc_tail);
+
+            // Accumulate the carried constants into the next round.
+            vec_accumulate(&mut rc[i + 1], &rc_carry);
+        }
+        // Now constants have accumulated into the next full round.
+
+        (rc, mds, inv)
+    }
+}
+
+fn mat_mul<Fp: FieldExt, const T: usize>(mat: &Mds<Fp, T>, input: &[Fp; T]) -> [Fp; T] {
+    let mut out = [Fp::zero(); T];
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..T {
+        for j in 0..T {
+            out[i] += mat[i][j] * input[j];
+        }
+    }
+    out
+}
+
+fn vec_accumulate<Fp: FieldExt, const T: usize>(a: &mut [Fp; T], b: &[Fp; T]) {
+    for i in 0..T {
+        a[i] += b[i];
+    }
+}
+
+fn vec_remove_tail<Fp: FieldExt, const T: usize>(a: &mut [Fp; T]) -> [Fp; T] {
+    let mut tail = [Fp::zero(); T];
+    for i in 1..T {
+        tail[i] = a[i];
+        a[i] = Fp::zero();
+    }
+    tail
+}


### PR DESCRIPTION
Calculate another version of the round constants such that only one constant per partial round is non-zero.

![image](https://user-images.githubusercontent.com/8718243/215765726-0ec3e9a8-a1d9-409f-93a9-26dc9ddc7d57.png)

This is plug-and-play compatible with the rest of the code. However, the 0 constants can be optimized in some places, such as removing fixed columns.

![image](https://user-images.githubusercontent.com/8718243/215766657-b0019c8b-c6eb-4498-87f5-0e6dd352d5af.png)

Note: this happens at runtime, but it should be hard-coded instead.


