### PR TITLE
Refactor septidon for the generic on field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ thiserror = "1.0"
 bitvec = "1"
 
 [patch."https://github.com/privacy-scaling-explorations/halo2.git"]
-halo2_proofs = { git = "https://github.com/scroll-tech/halo2.git", branch = "scroll-dev-1220" }
+halo2_proofs = { git = "https://github.com/scroll-tech/halo2.git", branch = "scroll-dev-0220" }
 
 [features]
 # Use an implementation using fewer rows (8) per permutation.

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -742,12 +742,12 @@ mod tests {
 
     // test circuit derived from table data
     //#[derive(Clone, Default, Debug)]
-    struct TestCircuit<PC: PermuteChip<Fr>> {
+    struct TestCircuit<PC> {
         table: PoseidonHashTable<Fr>,
         _phantom: PhantomData<PC>,
     }
 
-    impl<PC: PermuteChip<Fr>> TestCircuit<PC> {
+    impl<PC: PermuteChip<Fr, <Fr as Hashable>::SpecType, 3, 2>> TestCircuit<PC> {
         pub fn new(table: PoseidonHashTable<Fr>) -> Self {
             TestCircuit {
                 table,
@@ -756,7 +756,7 @@ mod tests {
         }
     }
 
-    impl<PC: PermuteChip<Fr> + PoseidonInstructions<Fr, <Fr as Hashable>::SpecType, 3, 2>>
+    impl<PC: PermuteChip<Fr, <Fr as Hashable>::SpecType, 3, 2>>
         Circuit<Fr> for TestCircuit<PC>
     {
         type Config = (SpongeConfig<Fr, PC>, usize);
@@ -826,7 +826,7 @@ mod tests {
     }
 
     fn poseidon_hash_circuit_impl<
-        PC: PermuteChip<Fr> + PoseidonInstructions<Fr, <Fr as Hashable>::SpecType, 3, 2>,
+        PC: PermuteChip<Fr, <Fr as Hashable>::SpecType, 3, 2>,
     >() {
         let message1 = [
             Fr::from_str_vartime("1").unwrap(),
@@ -854,7 +854,7 @@ mod tests {
     }
 
     fn poseidon_var_len_hash_circuit_impl<
-        PC: PermuteChip<Fr> + PoseidonInstructions<Fr, <Fr as Hashable>::SpecType, 3, 2>,
+        PC: PermuteChip<Fr, <Fr as Hashable>::SpecType, 3, 2>,
     >() {
         let message1 = [
             Fr::from_str_vartime("1").unwrap(),

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,8 +1,6 @@
 //! The hash circuit base on poseidon.
 
-use crate::poseidon::primitives::{
-    ConstantLengthIden3, Domain, Hash, Spec, VariableLengthIden3,
-};
+use crate::poseidon::primitives::{ConstantLengthIden3, Domain, Hash, Spec, VariableLengthIden3};
 use halo2_proofs::halo2curves::bn256::Fr;
 use halo2_proofs::{arithmetic::FieldExt, circuit::AssignedCell};
 
@@ -11,7 +9,7 @@ mod chip_long {
     use crate::poseidon::primitives::{P128Pow5T3, P128Pow5T3Constants};
     use crate::poseidon::Pow5Chip;
     /// The specified base hashable trait
-    pub trait Hashablebase : P128Pow5T3Constants{}
+    pub trait Hashablebase: P128Pow5T3Constants {}
     /// Set the spec type as P128Pow5T3
     pub type HashSpec<F> = P128Pow5T3<F>;
     /// The configuration of the Poseidon hash chip.
@@ -19,7 +17,6 @@ mod chip_long {
     /// The Poseidon hash chip.
     pub type PoseidonHashChip<'d, F, const STEP: usize> =
         SpongeChip<'d, F, STEP, Pow5Chip<F, 3, 2>>;
-    
 }
 
 mod chip_short {
@@ -27,7 +24,7 @@ mod chip_short {
     use crate::poseidon::primitives::P128Pow5T3Compact;
     use crate::poseidon::{CachedConstants, SeptidonChip};
     /// The specified base hashable trait
-    pub trait Hashablebase : CachedConstants{}
+    pub trait Hashablebase: CachedConstants {}
     /// Set the spec type as P128Pow5T3Compact
     pub type HashSpec<F> = P128Pow5T3Compact<F>;
     /// The configuration of the Poseidon hash chip.
@@ -373,12 +370,8 @@ pub struct SpongeChip<'d, Fp: FieldExt, const STEP: usize, PC: Chip<Fp> + Clone 
 type PermutedState<Word> = Vec<[Word; 3]>;
 type PermutedStatePair<Word> = (PermutedState<Word>, PermutedState<Word>);
 
-impl<
-        'd,
-        Fp: Hashable,
-        const STEP: usize,
-        PC: PermuteChip<Fp, Fp::SpecType, 3, 2>,
-    > SpongeChip<'d, Fp, STEP, PC>
+impl<'d, Fp: Hashable, const STEP: usize, PC: PermuteChip<Fp, Fp::SpecType, 3, 2>>
+    SpongeChip<'d, Fp, STEP, PC>
 {
     ///construct the chip
     pub fn construct(
@@ -458,7 +451,6 @@ impl<
 
         Ok(2)
     }
-
 
     fn fill_hash_tbl_body(
         &self,
@@ -761,9 +753,7 @@ mod tests {
         }
     }
 
-    impl<PC: PermuteChip<Fr, <Fr as Hashable>::SpecType, 3, 2>>
-        Circuit<Fr> for TestCircuit<PC>
-    {
+    impl<PC: PermuteChip<Fr, <Fr as Hashable>::SpecType, 3, 2>> Circuit<Fr> for TestCircuit<PC> {
         type Config = (SpongeConfig<Fr, PC>, usize);
         type FloorPlanner = SimpleFloorPlanner;
 
@@ -830,9 +820,7 @@ mod tests {
         poseidon_hash_circuit_impl::<SeptidonChip>();
     }
 
-    fn poseidon_hash_circuit_impl<
-        PC: PermuteChip<Fr, <Fr as Hashable>::SpecType, 3, 2>,
-    >() {
+    fn poseidon_hash_circuit_impl<PC: PermuteChip<Fr, <Fr as Hashable>::SpecType, 3, 2>>() {
         let message1 = [
             Fr::from_str_vartime("1").unwrap(),
             Fr::from_str_vartime("2").unwrap(),
@@ -858,9 +846,7 @@ mod tests {
         poseidon_var_len_hash_circuit_impl::<SeptidonChip>();
     }
 
-    fn poseidon_var_len_hash_circuit_impl<
-        PC: PermuteChip<Fr, <Fr as Hashable>::SpecType, 3, 2>,
-    >() {
+    fn poseidon_var_len_hash_circuit_impl<PC: PermuteChip<Fr, <Fr as Hashable>::SpecType, 3, 2>>() {
         let message1 = [
             Fr::from_str_vartime("1").unwrap(),
             Fr::from_str_vartime("2").unwrap(),

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,24 +1,33 @@
 //! The hash circuit base on poseidon.
 
 use crate::poseidon::primitives::{
-    ConstantLengthIden3, Domain, Hash, P128Pow5T3, Spec, VariableLengthIden3,
+    ConstantLengthIden3, Domain, Hash, Spec, VariableLengthIden3,
 };
 use halo2_proofs::halo2curves::bn256::Fr;
 use halo2_proofs::{arithmetic::FieldExt, circuit::AssignedCell};
 
 mod chip_long {
     use super::{SpongeChip, SpongeConfig};
+    use crate::poseidon::primitives::{P128Pow5T3, P128Pow5T3Constants};
     use crate::poseidon::Pow5Chip;
+    /// The specified base hashable trait
+    pub trait Hashablebase : P128Pow5T3Constants{}
+    /// Set the spec type as P128Pow5T3
+    pub type HashSpec<F> = P128Pow5T3<F>;
     /// The configuration of the Poseidon hash chip.
     pub type PoseidonHashConfig<F> = SpongeConfig<F, Pow5Chip<F, 3, 2>>;
     /// The Poseidon hash chip.
     pub type PoseidonHashChip<'d, F, const STEP: usize> =
         SpongeChip<'d, F, STEP, Pow5Chip<F, 3, 2>>;
+    
 }
 
 mod chip_short {
     use super::{SpongeChip, SpongeConfig};
+    use crate::poseidon::primitives::P128Pow5T3Compact;
     use crate::poseidon::SeptidonChip;
+    /// Set the spec type as P128Pow5T3Compact
+    pub type T3SpecImpl<F> = P128Pow5T3Compact<F>;
     /// The configuration of the Poseidon hash chip.
     pub type PoseidonHashConfig<F> = SpongeConfig<F, SeptidonChip>;
     /// The Poseidon hash chip.
@@ -34,7 +43,7 @@ pub use chip_long::*;
 pub use chip_short::*;
 
 /// indicate an field can be hashed in merkle tree (2 Fields to 1 Field)
-pub trait Hashable: FieldExt {
+pub trait Hashable: Hashablebase {
     /// the spec type used in circuit for this hashable field
     type SpecType: Spec<Self, 3, 2>;
     /// the domain type used for hash calculation
@@ -66,8 +75,10 @@ pub trait MessageHashable: Hashable {
     }
 }
 
+impl Hashablebase for Fr {}
+
 impl Hashable for Fr {
-    type SpecType = P128Pow5T3<Self>;
+    type SpecType = HashSpec<Self>;
     type DomainType = ConstantLengthIden3<2>;
 
     fn hash(inp: [Self; 2]) -> Self {
@@ -92,7 +103,7 @@ use halo2_proofs::{
 
 /// The config for poseidon hash circuit
 #[derive(Clone, Debug)]
-pub struct SpongeConfig<Fp: FieldExt, PC: PermuteChip<Fp>> {
+pub struct SpongeConfig<Fp: FieldExt, PC: Chip<Fp>> {
     permute_config: PC::Config,
     hash_table: [Column<Advice>; 5],
     hash_table_aux: [Column<Advice>; 6],
@@ -103,7 +114,7 @@ pub struct SpongeConfig<Fp: FieldExt, PC: PermuteChip<Fp>> {
     s_custom: Selector,
 }
 
-impl<Fp: Hashable, PC: PermuteChip<Fp>> SpongeConfig<Fp, PC> {
+impl<Fp: Hashable, PC: PermuteChip<Fp, Fp::SpecType, 3, 2>> SpongeConfig<Fp, PC> {
     /// obtain the commitment index of hash table
     pub fn commitment_index(&self) -> [usize; 5] {
         self.hash_table.map(|col| col.index())
@@ -348,7 +359,7 @@ impl<Fp: Hashable> PoseidonHashTable<Fp> {
 
 /// Represent the chip for Poseidon hash table
 #[derive(Debug)]
-pub struct SpongeChip<'d, Fp: FieldExt, const STEP: usize, PC: PermuteChip<Fp>> {
+pub struct SpongeChip<'d, Fp: Hashable, const STEP: usize, PC: PermuteChip<Fp, Fp::SpecType, 3, 2>> {
     calcs: usize,
     nil_msg_hash: Option<Fp>,
     mpt_only: bool,
@@ -362,7 +373,7 @@ impl<
         'd,
         Fp: Hashable,
         const STEP: usize,
-        PC: PermuteChip<Fp> + PoseidonInstructions<Fp, Fp::SpecType, 3, 2>,
+        PC: PermuteChip<Fp, Fp::SpecType, 3, 2>,
     > SpongeChip<'d, Fp, STEP, PC>
 {
     ///construct the chip
@@ -658,7 +669,7 @@ impl<
     }
 }
 
-impl<Fp: FieldExt, const STEP: usize, PC: PermuteChip<Fp>> Chip<Fp>
+impl<Fp: FieldExt, const STEP: usize, PC: Chip<Fp>> Chip<Fp>
     for SpongeChip<'_, Fp, STEP, PC>
 {
     type Config = SpongeConfig<Fp, PC>;

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -25,9 +25,11 @@ mod chip_long {
 mod chip_short {
     use super::{SpongeChip, SpongeConfig};
     use crate::poseidon::primitives::P128Pow5T3Compact;
-    use crate::poseidon::SeptidonChip;
+    use crate::poseidon::{CachedConstants, SeptidonChip};
+    /// The specified base hashable trait
+    pub trait Hashablebase : CachedConstants{}
     /// Set the spec type as P128Pow5T3Compact
-    pub type T3SpecImpl<F> = P128Pow5T3Compact<F>;
+    pub type HashSpec<F> = P128Pow5T3Compact<F>;
     /// The configuration of the Poseidon hash chip.
     pub type PoseidonHashConfig<F> = SpongeConfig<F, SeptidonChip>;
     /// The Poseidon hash chip.
@@ -100,10 +102,11 @@ use halo2_proofs::{
     plonk::{Advice, Column, ConstraintSystem, Error, Expression, Selector, TableColumn},
     poly::Rotation,
 };
+use std::fmt::Debug as DebugT;
 
 /// The config for poseidon hash circuit
 #[derive(Clone, Debug)]
-pub struct SpongeConfig<Fp: FieldExt, PC: Chip<Fp>> {
+pub struct SpongeConfig<Fp: FieldExt, PC: Chip<Fp> + Clone + DebugT> {
     permute_config: PC::Config,
     hash_table: [Column<Advice>; 5],
     hash_table_aux: [Column<Advice>; 6],
@@ -359,7 +362,7 @@ impl<Fp: Hashable> PoseidonHashTable<Fp> {
 
 /// Represent the chip for Poseidon hash table
 #[derive(Debug)]
-pub struct SpongeChip<'d, Fp: Hashable, const STEP: usize, PC: PermuteChip<Fp, Fp::SpecType, 3, 2>> {
+pub struct SpongeChip<'d, Fp: FieldExt, const STEP: usize, PC: Chip<Fp> + Clone + DebugT> {
     calcs: usize,
     nil_msg_hash: Option<Fp>,
     mpt_only: bool,
@@ -669,7 +672,7 @@ impl<
     }
 }
 
-impl<Fp: FieldExt, const STEP: usize, PC: Chip<Fp>> Chip<Fp>
+impl<Fp: FieldExt, const STEP: usize, PC: Chip<Fp> + Clone + DebugT> Chip<Fp>
     for SpongeChip<'_, Fp, STEP, PC>
 {
     type Config = SpongeConfig<Fp, PC>;

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -371,6 +371,7 @@ pub struct SpongeChip<'d, Fp: FieldExt, const STEP: usize, PC: Chip<Fp> + Clone 
 }
 
 type PermutedState<Word> = Vec<[Word; 3]>;
+type PermutedStatePair<Word> = (PermutedState<Word>, PermutedState<Word>);
 
 impl<
         'd,
@@ -458,11 +459,12 @@ impl<
         Ok(2)
     }
 
+
     fn fill_hash_tbl_body(
         &self,
         region: &mut Region<'_, Fp>,
         begin_offset: usize,
-    ) -> Result<(PermutedState<PC::Word>, PermutedState<PC::Word>), Error> {
+    ) -> Result<PermutedStatePair<PC::Word>, Error> {
         let config = &self.config;
         let data = self.data;
 

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -14,7 +14,8 @@ mod pow5;
 pub use pow5::{Pow5Chip, Pow5Config, StateWord, Var};
 
 mod septidon;
-pub use septidon::SeptidonChip;
+pub use septidon::{CachedConstants, SeptidonChip};
+
 
 pub mod primitives;
 use primitives::{Absorbing, ConstantLength, Domain, Spec, SpongeMode, Squeezing, State};

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -30,7 +30,8 @@ pub enum PaddedWord<F: Field> {
 }
 
 /// This trait is the interface to chips that implement a permutation.
-pub trait PermuteChip<F: FieldExt>: Chip<F> + Clone + DebugT {
+pub trait PermuteChip<F: FieldExt, S: Spec<F, T, RATE>, const T: usize, const RATE: usize>: 
+    Chip<F> + Clone + DebugT + PoseidonInstructions<F, S, T, RATE>{
     /// Configure the permutation chip.
     fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config;
 

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -16,7 +16,6 @@ pub use pow5::{Pow5Chip, Pow5Config, StateWord, Var};
 mod septidon;
 pub use septidon::{CachedConstants, SeptidonChip};
 
-
 pub mod primitives;
 use primitives::{Absorbing, ConstantLength, Domain, Spec, SpongeMode, Squeezing, State};
 use std::fmt::Debug as DebugT;
@@ -31,8 +30,9 @@ pub enum PaddedWord<F: Field> {
 }
 
 /// This trait is the interface to chips that implement a permutation.
-pub trait PermuteChip<F: FieldExt, S: Spec<F, T, RATE>, const T: usize, const RATE: usize>: 
-    Chip<F> + Clone + DebugT + PoseidonInstructions<F, S, T, RATE>{
+pub trait PermuteChip<F: FieldExt, S: Spec<F, T, RATE>, const T: usize, const RATE: usize>:
+    Chip<F> + Clone + DebugT + PoseidonInstructions<F, S, T, RATE>
+{
     /// Configure the permutation chip.
     fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config;
 

--- a/src/poseidon/pow5.rs
+++ b/src/poseidon/pow5.rs
@@ -258,7 +258,7 @@ impl<F: FieldExt, const WIDTH: usize, const RATE: usize> Chip<F> for Pow5Chip<F,
     }
 }
 
-impl<F: FieldExt, S: Spec<F, 3, 2>> PermuteChip<F, S> for Pow5Chip<F, 3, 2> {
+impl<F: FieldExt, S: Spec<F, 3, 2>> PermuteChip<F, S, 3, 2> for Pow5Chip<F, 3, 2> {
     fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
         let state = [0; 3].map(|_| meta.advice_column());
         let partial_sbox = meta.advice_column();

--- a/src/poseidon/pow5.rs
+++ b/src/poseidon/pow5.rs
@@ -8,8 +8,6 @@ use halo2_proofs::{
     poly::Rotation,
 };
 
-use crate::Hashable;
-
 use super::{
     primitives::{Absorbing, Domain, Mds, Spec, Squeezing, State},
     PaddedWord, PermuteChip, PoseidonInstructions, PoseidonSpongeInstructions,
@@ -260,13 +258,13 @@ impl<F: FieldExt, const WIDTH: usize, const RATE: usize> Chip<F> for Pow5Chip<F,
     }
 }
 
-impl<F: Hashable> PermuteChip<F> for Pow5Chip<F, 3, 2> {
+impl<F: FieldExt, S: Spec<F, 3, 2>> PermuteChip<F, S> for Pow5Chip<F, 3, 2> {
     fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
         let state = [0; 3].map(|_| meta.advice_column());
         let partial_sbox = meta.advice_column();
         let constants = [0; 6].map(|_| meta.fixed_column());
 
-        Pow5Chip::configure::<F::SpecType>(
+        Pow5Chip::configure::<S>(
             meta,
             state,
             partial_sbox,

--- a/src/poseidon/primitives.rs
+++ b/src/poseidon/primitives.rs
@@ -26,6 +26,7 @@ pub(crate) mod pasta;
 mod p128pow5t3;
 mod p128pow5t3_compact;
 
+pub(crate) use p128pow5t3::P128Pow5T3Constants;
 pub use p128pow5t3::P128Pow5T3;
 pub use p128pow5t3_compact::P128Pow5T3Compact;
 

--- a/src/poseidon/primitives.rs
+++ b/src/poseidon/primitives.rs
@@ -26,8 +26,8 @@ pub(crate) mod pasta;
 mod p128pow5t3;
 mod p128pow5t3_compact;
 
-pub(crate) use p128pow5t3::P128Pow5T3Constants;
 pub use p128pow5t3::P128Pow5T3;
+pub(crate) use p128pow5t3::P128Pow5T3Constants;
 pub use p128pow5t3_compact::P128Pow5T3Compact;
 
 use grain::SboxType;

--- a/src/poseidon/primitives/p128pow5t3.rs
+++ b/src/poseidon/primitives/p128pow5t3.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 
 use super::{Mds, Spec};
 
+/// The trait required for fields can handle a pow5 sbox, 3 field, 2 rate permutation
 pub trait P128Pow5T3Constants: FieldExt {
     fn partial_rounds() -> usize {
         56

--- a/src/poseidon/septidon.rs
+++ b/src/poseidon/septidon.rs
@@ -15,3 +15,4 @@ mod transition_round;
 mod util;
 
 pub use septidon_chip::SeptidonChip;
+pub use params::CachedConstants;

--- a/src/poseidon/septidon.rs
+++ b/src/poseidon/septidon.rs
@@ -14,5 +14,5 @@ mod tests;
 mod transition_round;
 mod util;
 
-pub use septidon_chip::SeptidonChip;
 pub use params::CachedConstants;
+pub use septidon_chip::SeptidonChip;

--- a/src/poseidon/septidon/control.rs
+++ b/src/poseidon/septidon/control.rs
@@ -1,7 +1,7 @@
 use super::params::GATE_DEGREE_5;
 use super::util::query;
-use halo2_proofs::circuit::{Region, Value};
 use halo2_proofs::arithmetic::FieldExt;
+use halo2_proofs::circuit::{Region, Value};
 //use halo2_proofs::halo2curves::bn256::Fr as F;
 use halo2_proofs::plonk::{Column, ConstraintSystem, Error, Expression, Fixed, VirtualCells};
 use halo2_proofs::poly::Rotation;
@@ -48,7 +48,10 @@ impl ControlChip {
         Ok(())
     }
 
-    fn derive_selector<F: FieldExt>(is_last: Column<Fixed>, meta: &mut VirtualCells<'_, F>) -> Expression<F> {
+    fn derive_selector<F: FieldExt>(
+        is_last: Column<Fixed>,
+        meta: &mut VirtualCells<'_, F>,
+    ) -> Expression<F> {
         if GATE_DEGREE_5 {
             // Variant with no selector. Do not disable gates, do not increase the gate degree.
             Expression::Constant(F::one())

--- a/src/poseidon/septidon/control.rs
+++ b/src/poseidon/septidon/control.rs
@@ -1,7 +1,8 @@
 use super::params::GATE_DEGREE_5;
 use super::util::query;
 use halo2_proofs::circuit::{Region, Value};
-use halo2_proofs::halo2curves::bn256::Fr as F;
+use halo2_proofs::arithmetic::FieldExt;
+//use halo2_proofs::halo2curves::bn256::Fr as F;
 use halo2_proofs::plonk::{Column, ConstraintSystem, Error, Expression, Fixed, VirtualCells};
 use halo2_proofs::poly::Rotation;
 
@@ -10,7 +11,7 @@ pub struct ControlChip {
     is_last: Column<Fixed>,
 }
 
-pub struct ControlSignals {
+pub struct ControlSignals<F: FieldExt> {
     // Signals that control the switches between steps of the permutation.
     pub break_full_rounds: Expression<F>,
     pub transition_round: Expression<F>,
@@ -21,7 +22,7 @@ pub struct ControlSignals {
 }
 
 impl ControlChip {
-    pub fn configure(cs: &mut ConstraintSystem<F>) -> (Self, ControlSignals) {
+    pub fn configure<F: FieldExt>(cs: &mut ConstraintSystem<F>) -> (Self, ControlSignals<F>) {
         let is_last = cs.fixed_column();
 
         let signals = query(cs, |meta| {
@@ -42,12 +43,12 @@ impl ControlChip {
     }
 
     /// Assign the fixed positions of the last row of permutations.
-    pub fn assign(&self, region: &mut Region<'_, F>) -> Result<(), Error> {
+    pub fn assign<F: FieldExt>(&self, region: &mut Region<'_, F>) -> Result<(), Error> {
         region.assign_fixed(|| "", self.is_last, 7, || Value::known(F::one()))?;
         Ok(())
     }
 
-    fn derive_selector(is_last: Column<Fixed>, meta: &mut VirtualCells<'_, F>) -> Expression<F> {
+    fn derive_selector<F: FieldExt>(is_last: Column<Fixed>, meta: &mut VirtualCells<'_, F>) -> Expression<F> {
         if GATE_DEGREE_5 {
             // Variant with no selector. Do not disable gates, do not increase the gate degree.
             Expression::Constant(F::one())

--- a/src/poseidon/septidon/full_round.rs
+++ b/src/poseidon/septidon/full_round.rs
@@ -22,7 +22,10 @@ impl FullRoundChip {
         (chip, loop_body)
     }
 
-    fn full_round_expr<F: CachedConstants>(&self, meta: &mut VirtualCells<'_, F>) -> [Expression<F>; 3] {
+    fn full_round_expr<F: CachedConstants>(
+        &self,
+        meta: &mut VirtualCells<'_, F>,
+    ) -> [Expression<F>; 3] {
         let sbox_out = self.0.map(|sbox: &SBox| sbox.output_expr(meta));
         matmul::expr(mds(), sbox_out)
     }

--- a/src/poseidon/septidon/full_round.rs
+++ b/src/poseidon/septidon/full_round.rs
@@ -24,7 +24,7 @@ impl FullRoundChip {
 
     fn full_round_expr<F: CachedConstants>(&self, meta: &mut VirtualCells<'_, F>) -> [Expression<F>; 3] {
         let sbox_out = self.0.map(|sbox: &SBox| sbox.output_expr(meta));
-        matmul::expr(&mds(), sbox_out)
+        matmul::expr(mds(), sbox_out)
     }
 
     pub fn input_cells(&self) -> [Cell; 3] {
@@ -44,7 +44,7 @@ impl FullRoundChip {
             let sbox: &SBox = &self.0 .0[i];
             sbox_out[i] = sbox.assign(region, offset, round_constants[i], input[i])?;
         }
-        let output = join_values(sbox_out).map(|sbox_out| matmul::value(&mds(), sbox_out));
+        let output = join_values(sbox_out).map(|sbox_out| matmul::value(mds(), sbox_out));
         Ok(split_values(output))
     }
 }

--- a/src/poseidon/septidon/instruction.rs
+++ b/src/poseidon/septidon/instruction.rs
@@ -49,7 +49,7 @@ impl<F: CachedConstants, S: Spec<F, WIDTH, RATE>> PoseidonInstructions<F, S, WID
                 let chip_input = self.initial_state_cells();
                 for i in 0..WIDTH {
                     initial_state[i].0.copy_advice(
-                        || format!("load state_{}", i),
+                        || format!("load state_{i}"),
                         region,
                         chip_input[i].column,
                         chip_input[i].offset as usize,
@@ -57,7 +57,7 @@ impl<F: CachedConstants, S: Spec<F, WIDTH, RATE>> PoseidonInstructions<F, S, WID
                 }
 
                 // Assign the internal witness of the permutation.
-                let initial_values = map_array(&initial_state, |word| word.value());
+                let initial_values = map_array(initial_state, |word| word.value());
                 let final_values = self.assign_permutation(region, initial_values)?;
 
                 // Return the cells containing the final state.

--- a/src/poseidon/septidon/instruction.rs
+++ b/src/poseidon/septidon/instruction.rs
@@ -3,11 +3,11 @@ use super::super::{
     PermuteChip, PoseidonInstructions, StateWord, Var,
 };
 use super::{params::CachedConstants, util::map_array, SeptidonChip};
+use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::{
     circuit::{Chip, Layouter},
     plonk::{ConstraintSystem, Error},
 };
-use halo2_proofs::arithmetic::FieldExt;
 
 const WIDTH: usize = 3;
 const RATE: usize = 2;
@@ -32,7 +32,9 @@ impl<F: CachedConstants, S: Spec<F, WIDTH, RATE>> PermuteChip<F, S, WIDTH, RATE>
     }
 }
 
-impl<F: CachedConstants, S: Spec<F, WIDTH, RATE>> PoseidonInstructions<F, S, WIDTH, RATE> for SeptidonChip {
+impl<F: CachedConstants, S: Spec<F, WIDTH, RATE>> PoseidonInstructions<F, S, WIDTH, RATE>
+    for SeptidonChip
+{
     type Word = StateWord<F>;
 
     fn permute(

--- a/src/poseidon/septidon/instruction.rs
+++ b/src/poseidon/septidon/instruction.rs
@@ -2,16 +2,17 @@ use super::super::{
     primitives::{Spec, State},
     PermuteChip, PoseidonInstructions, StateWord, Var,
 };
-use super::{params::F, util::map_array, SeptidonChip};
+use super::{params::CachedConstants, util::map_array, SeptidonChip};
 use halo2_proofs::{
     circuit::{Chip, Layouter},
     plonk::{ConstraintSystem, Error},
 };
+use halo2_proofs::arithmetic::FieldExt;
 
 const WIDTH: usize = 3;
 const RATE: usize = 2;
 
-impl PermuteChip<F> for SeptidonChip {
+impl<F: CachedConstants, S: Spec<F, WIDTH, RATE>> PermuteChip<F, S, WIDTH, RATE> for SeptidonChip {
     fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
         let chip = Self::configure(meta);
 
@@ -31,7 +32,7 @@ impl PermuteChip<F> for SeptidonChip {
     }
 }
 
-impl<S: Spec<F, WIDTH, RATE>> PoseidonInstructions<F, S, WIDTH, RATE> for SeptidonChip {
+impl<F: CachedConstants, S: Spec<F, WIDTH, RATE>> PoseidonInstructions<F, S, WIDTH, RATE> for SeptidonChip {
     type Word = StateWord<F>;
 
     fn permute(
@@ -80,7 +81,7 @@ impl<S: Spec<F, WIDTH, RATE>> PoseidonInstructions<F, S, WIDTH, RATE> for Septid
     }
 }
 
-impl Chip<F> for SeptidonChip {
+impl<F: FieldExt> Chip<F> for SeptidonChip {
     type Config = Self;
 
     type Loaded = ();

--- a/src/poseidon/septidon/loop_chip.rs
+++ b/src/poseidon/septidon/loop_chip.rs
@@ -1,22 +1,23 @@
 use super::state::Cell;
 use super::util::select;
-use halo2_proofs::halo2curves::bn256::Fr as F;
+use halo2_proofs::arithmetic::FieldExt;
+//use halo2_proofs::halo2curves::bn256::Fr as F;
 use halo2_proofs::plonk::{ConstraintSystem, Constraints, Expression};
 
 #[derive(Clone, Debug)]
 pub struct LoopChip {}
 
-pub struct LoopBody {
+pub struct LoopBody<F> {
     pub next_state: [Expression<F>; 3],
     /// Cells where the output is, relative to the break signal.
     pub output: [Expression<F>; 3],
 }
 
 impl LoopChip {
-    pub fn configure(
+    pub fn configure<F: FieldExt>(
         cs: &mut ConstraintSystem<F>,
         q: Expression<F>,
-        body: LoopBody,
+        body: LoopBody<F>,
         break_signal: Expression<F>,
         output: [Cell; 3],
     ) -> Self {

--- a/src/poseidon/septidon/params.rs
+++ b/src/poseidon/septidon/params.rs
@@ -1,41 +1,63 @@
-use super::super::primitives::{Mds as MdsT, P128Pow5T3Compact, Spec};
-use lazy_static::lazy_static;
+use super::super::primitives::{Mds as MdsT, P128Pow5T3Constants};
 
 /// This implementation can be limited to gate degree 5. However, this mode will not work with
 /// blinding or inactive rows. Enable only with a prover that supports assignments to all n rows.
 pub const GATE_DEGREE_5: bool = false;
 
-/// This implementation supports only the scalar field of BN254 at the moment.
-///
-/// To implement for the Pasta curves, adjust the parameters below, and replace the transition round
-/// by a copy, to get 56 rounds instead of 57.
-pub use halo2_proofs::halo2curves::bn256::Fr as F;
+/// This is the base "hashable" type requirement for septidon
+pub trait CachedConstants : P128Pow5T3Constants {
+    /// cached round constants
+    fn cached_round_constants() -> &'static [[Self; 3]];
+    /// cached mds
+    fn cached_mds() -> &'static Mds<Self>;
+    /// cached inversed mds
+    fn cached_mds_inv() -> &'static Mds<Self>;
+}
+
 
 pub mod sbox {
     use super::super::util::pow_5;
-    use super::F;
+    use halo2_proofs::arithmetic::FieldExt;
     use halo2_proofs::plonk::Expression;
 
-    pub fn expr(input: Expression<F>, round_constant: Expression<F>) -> Expression<F> {
+    pub fn expr<F:FieldExt>(input: Expression<F>, round_constant: Expression<F>) -> Expression<F> {
         pow_5::expr(input + round_constant)
     }
 
-    pub fn value(input: F, round_constant: F) -> F {
+    pub fn value<F:FieldExt>(input: F, round_constant: F) -> F {
         pow_5::value(input + round_constant)
     }
 }
 
-pub type Mds = MdsT<F, 3>;
+pub type Mds<F> = MdsT<F, 3>;
 
-lazy_static! {
-    // Cache the round constants and the MDS matrix (and unused inverse MDS matrix).
-    static ref CONSTANTS: (Vec<[F; 3]>, Mds, Mds) = P128Pow5T3Compact::<F>::constants();
+mod bn254 {
+    use lazy_static::lazy_static;
+    use super::{Mds, CachedConstants};
+    use crate::poseidon::primitives::{P128Pow5T3Compact, Spec};
+    use halo2_proofs::halo2curves::bn256::Fr as F;
+    lazy_static! {
+        // Cache the round constants and the MDS matrix (and unused inverse MDS matrix).
+        static ref CONSTANTS: (Vec<[F; 3]>, Mds<F>, Mds<F>) =  P128Pow5T3Compact::<F>::constants();
+    }
+
+    impl CachedConstants for F {
+        fn cached_round_constants() -> &'static [[Self; 3]]{
+            &CONSTANTS.0
+        }
+        fn cached_mds() -> &'static Mds<Self>{
+            &CONSTANTS.1
+        }
+        fn cached_mds_inv() -> &'static Mds<Self>{
+            &CONSTANTS.2
+        }
+    }
 }
 
-pub fn round_constant(index: usize) -> [F; 3] {
-    CONSTANTS.0[index]
+pub fn round_constant<F:CachedConstants>(index: usize) -> [F; 3] {
+    F::cached_round_constants()[index]
 }
 
-pub fn mds() -> &'static Mds {
-    &CONSTANTS.1
+pub fn mds<F:CachedConstants>() -> &'static Mds<F> {
+    F::cached_mds()
 }

--- a/src/poseidon/septidon/params.rs
+++ b/src/poseidon/septidon/params.rs
@@ -5,7 +5,7 @@ use super::super::primitives::{Mds as MdsT, P128Pow5T3Constants};
 pub const GATE_DEGREE_5: bool = false;
 
 /// This is the base "hashable" type requirement for septidon
-pub trait CachedConstants : P128Pow5T3Constants {
+pub trait CachedConstants: P128Pow5T3Constants {
     /// cached round constants
     fn cached_round_constants() -> &'static [[Self; 3]];
     /// cached mds
@@ -14,17 +14,16 @@ pub trait CachedConstants : P128Pow5T3Constants {
     fn cached_mds_inv() -> &'static Mds<Self>;
 }
 
-
 pub mod sbox {
     use super::super::util::pow_5;
     use halo2_proofs::arithmetic::FieldExt;
     use halo2_proofs::plonk::Expression;
 
-    pub fn expr<F:FieldExt>(input: Expression<F>, round_constant: Expression<F>) -> Expression<F> {
+    pub fn expr<F: FieldExt>(input: Expression<F>, round_constant: Expression<F>) -> Expression<F> {
         pow_5::expr(input + round_constant)
     }
 
-    pub fn value<F:FieldExt>(input: F, round_constant: F) -> F {
+    pub fn value<F: FieldExt>(input: F, round_constant: F) -> F {
         pow_5::value(input + round_constant)
     }
 }
@@ -32,32 +31,32 @@ pub mod sbox {
 pub type Mds<F> = MdsT<F, 3>;
 
 mod bn254 {
-    use lazy_static::lazy_static;
-    use super::{Mds, CachedConstants};
+    use super::{CachedConstants, Mds};
     use crate::poseidon::primitives::{P128Pow5T3Compact, Spec};
     use halo2_proofs::halo2curves::bn256::Fr as F;
+    use lazy_static::lazy_static;
     lazy_static! {
         // Cache the round constants and the MDS matrix (and unused inverse MDS matrix).
         static ref CONSTANTS: (Vec<[F; 3]>, Mds<F>, Mds<F>) =  P128Pow5T3Compact::<F>::constants();
     }
 
     impl CachedConstants for F {
-        fn cached_round_constants() -> &'static [[Self; 3]]{
+        fn cached_round_constants() -> &'static [[Self; 3]] {
             &CONSTANTS.0
         }
-        fn cached_mds() -> &'static Mds<Self>{
+        fn cached_mds() -> &'static Mds<Self> {
             &CONSTANTS.1
         }
-        fn cached_mds_inv() -> &'static Mds<Self>{
+        fn cached_mds_inv() -> &'static Mds<Self> {
             &CONSTANTS.2
         }
     }
 }
 
-pub fn round_constant<F:CachedConstants>(index: usize) -> [F; 3] {
+pub fn round_constant<F: CachedConstants>(index: usize) -> [F; 3] {
     F::cached_round_constants()[index]
 }
 
-pub fn mds<F:CachedConstants>() -> &'static Mds<F> {
+pub fn mds<F: CachedConstants>() -> &'static Mds<F> {
     F::cached_mds()
 }

--- a/src/poseidon/septidon/septidon_chip.rs
+++ b/src/poseidon/septidon/septidon_chip.rs
@@ -80,14 +80,12 @@ impl SeptidonChip {
             )
         };
 
-        let chip = Self {
+        Self {
             control_chip,
             transition_chip,
             full_round_chip,
             partial_round_chip,
-        };
-
-        chip
+        }
     }
 
     /// How many rows are used per permutation.

--- a/src/poseidon/septidon/septidon_chip.rs
+++ b/src/poseidon/septidon/septidon_chip.rs
@@ -1,11 +1,11 @@
 use halo2_proofs::circuit::{Region, Value};
-use halo2_proofs::halo2curves::bn256::Fr as F;
+//use halo2_proofs::halo2curves::bn256::Fr as F;
 use halo2_proofs::plonk::{ConstraintSystem, Error};
 
 use super::control::ControlChip;
 use super::full_round::FullRoundChip;
 use super::loop_chip::LoopChip;
-use super::params::round_constant;
+use super::params::{round_constant, CachedConstants};
 use super::septuple_round::SeptupleRoundChip;
 use super::state::Cell;
 use super::transition_round::TransitionRoundChip;
@@ -34,7 +34,7 @@ pub struct SeptidonChip {
 
 impl SeptidonChip {
     /// Create a new chip.
-    pub fn configure(cs: &mut ConstraintSystem<F>) -> Self {
+    pub fn configure<F: CachedConstants>(cs: &mut ConstraintSystem<F>) -> Self {
         let (control_chip, signals) = ControlChip::configure(cs);
         let q = || signals.selector.clone();
 
@@ -115,7 +115,7 @@ impl SeptidonChip {
     }
 
     /// Assign the witness of a permutation into the given region.
-    pub fn assign_permutation(
+    pub fn assign_permutation<F: CachedConstants>(
         &self,
         region: &mut Region<'_, F>,
         initial_state: [Value<F>; 3],

--- a/src/poseidon/septidon/septuple_round.rs
+++ b/src/poseidon/septidon/septuple_round.rs
@@ -79,7 +79,7 @@ impl SeptupleRoundChip {
         input: &[Expression<F>; 3],
     ) -> [Expression<F>; 3] {
         let sbox_out = [sbox.output_expr(meta), input[1].clone(), input[2].clone()];
-        matmul::expr(&mds(), sbox_out)
+        matmul::expr(mds(), sbox_out)
     }
 
     pub fn input(&self) -> [Cell; 3] {
@@ -108,7 +108,7 @@ impl SeptupleRoundChip {
             // Assign the following S-Boxes.
             state[0] = sbox.assign(region, offset, round_constants[i], state[0])?;
             // Apply the matrix.
-            state = split_values(join_values(state).map(|s| matmul::value(&mds(), s)));
+            state = split_values(join_values(state).map(|s| matmul::value(mds(), s)));
             Ok(())
         };
 

--- a/src/poseidon/septidon/septuple_round.rs
+++ b/src/poseidon/septidon/septuple_round.rs
@@ -14,7 +14,10 @@ pub struct SeptupleRoundChip {
 }
 
 impl SeptupleRoundChip {
-    pub fn configure<F: CachedConstants>(cs: &mut ConstraintSystem<F>, q: Expression<F>) -> (Self, LoopBody<F>) {
+    pub fn configure<F: CachedConstants>(
+        cs: &mut ConstraintSystem<F>,
+        q: Expression<F>,
+    ) -> (Self, LoopBody<F>) {
         let chip = Self {
             first_sbox: SBox::configure(cs),
             first_linears: [Cell::configure(cs), Cell::configure(cs)],

--- a/src/poseidon/septidon/septuple_round.rs
+++ b/src/poseidon/septidon/septuple_round.rs
@@ -1,9 +1,9 @@
 use super::loop_chip::LoopBody;
-use super::params::mds;
+use super::params::{mds, CachedConstants};
 use super::state::{Cell, SBox};
 use super::util::{join_values, matmul, query, split_values};
 use halo2_proofs::circuit::{Region, Value};
-use halo2_proofs::halo2curves::bn256::Fr as F;
+//use halo2_proofs::halo2curves::bn256::Fr as F;
 use halo2_proofs::plonk::{ConstraintSystem, Constraints, Error, Expression, VirtualCells};
 
 #[derive(Clone, Debug)]
@@ -14,7 +14,7 @@ pub struct SeptupleRoundChip {
 }
 
 impl SeptupleRoundChip {
-    pub fn configure(cs: &mut ConstraintSystem<F>, q: Expression<F>) -> (Self, LoopBody) {
+    pub fn configure<F: CachedConstants>(cs: &mut ConstraintSystem<F>, q: Expression<F>) -> (Self, LoopBody<F>) {
         let chip = Self {
             first_sbox: SBox::configure(cs),
             first_linears: [Cell::configure(cs), Cell::configure(cs)],
@@ -73,7 +73,7 @@ impl SeptupleRoundChip {
         (chip, loop_body)
     }
 
-    fn partial_round_expr(
+    fn partial_round_expr<F: CachedConstants>(
         meta: &mut VirtualCells<'_, F>,
         sbox: &SBox,
         input: &[Expression<F>; 3],
@@ -91,7 +91,7 @@ impl SeptupleRoundChip {
     }
 
     /// Assign the witness.
-    pub fn assign(
+    pub fn assign<F: CachedConstants>(
         &self,
         region: &mut Region<'_, F>,
         offset: usize,

--- a/src/poseidon/septidon/state.rs
+++ b/src/poseidon/septidon/state.rs
@@ -1,6 +1,7 @@
 use super::params;
 use halo2_proofs::circuit::{Region, Value};
-use halo2_proofs::halo2curves::bn256::Fr as F;
+//use halo2_proofs::halo2curves::bn256::Fr as F;
+use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::plonk::{
     Advice, Column, ConstraintSystem, Error, Expression, Fixed, VirtualCells,
 };
@@ -16,7 +17,7 @@ pub struct Cell {
 }
 
 impl Cell {
-    pub fn configure(cs: &mut ConstraintSystem<F>) -> Self {
+    pub fn configure<F: FieldExt>(cs: &mut ConstraintSystem<F>) -> Self {
         Cell {
             column: cs.advice_column(),
             offset: 0,
@@ -34,7 +35,7 @@ impl Cell {
         }
     }
 
-    pub fn query(&self, meta: &mut VirtualCells<F>, offset: i32) -> Expression<F> {
+    pub fn query<F: FieldExt>(&self, meta: &mut VirtualCells<F>, offset: i32) -> Expression<F> {
         meta.query_advice(self.column, Rotation(self.offset + offset))
     }
 
@@ -43,7 +44,7 @@ impl Cell {
         self.offset as usize
     }
 
-    pub fn assign(
+    pub fn assign<F: FieldExt>(
         &self,
         region: &mut Region<'_, F>,
         origin_offset: usize,
@@ -63,7 +64,7 @@ pub struct SBox {
 }
 
 impl SBox {
-    pub fn configure(cs: &mut ConstraintSystem<F>) -> Self {
+    pub fn configure<F: FieldExt>(cs: &mut ConstraintSystem<F>) -> Self {
         SBox {
             input: Cell::configure(cs),
             round_constant: cs.fixed_column(),
@@ -71,7 +72,7 @@ impl SBox {
     }
 
     /// Assign the witness of the input.
-    pub fn assign(
+    pub fn assign<F: FieldExt>(
         &self,
         region: &mut Region<'_, F>,
         offset: usize,
@@ -94,15 +95,15 @@ impl SBox {
         Ok(output)
     }
 
-    pub fn input_expr(&self, meta: &mut VirtualCells<'_, F>) -> Expression<F> {
+    pub fn input_expr<F: FieldExt>(&self, meta: &mut VirtualCells<'_, F>) -> Expression<F> {
         self.input.query(meta, 0)
     }
 
-    pub fn rc_expr(&self, meta: &mut VirtualCells<'_, F>) -> Expression<F> {
+    pub fn rc_expr<F: FieldExt>(&self, meta: &mut VirtualCells<'_, F>) -> Expression<F> {
         meta.query_fixed(self.round_constant, Rotation(self.input.offset))
     }
 
-    pub fn output_expr(&self, meta: &mut VirtualCells<'_, F>) -> Expression<F> {
+    pub fn output_expr<F: FieldExt>(&self, meta: &mut VirtualCells<'_, F>) -> Expression<F> {
         let input = self.input_expr(meta);
         let round_constant = self.rc_expr(meta);
         params::sbox::expr(input, round_constant)
@@ -113,7 +114,7 @@ impl SBox {
 pub struct FullState(pub [SBox; 3]);
 
 impl FullState {
-    pub fn configure(cs: &mut ConstraintSystem<F>) -> Self {
+    pub fn configure<F: FieldExt>(cs: &mut ConstraintSystem<F>) -> Self {
         Self([
             SBox::configure(cs),
             SBox::configure(cs),

--- a/src/poseidon/septidon/tests.rs
+++ b/src/poseidon/septidon/tests.rs
@@ -39,6 +39,8 @@ impl Circuit<F> for TestCircuit {
         config: SeptidonChip,
         mut layouter: impl Layouter<F>,
     ) -> Result<(), Error> {
+        use halo2_proofs::dev::unwrap_value;
+
         let num_permutations = self.height / 8;
 
         for _ in 0..num_permutations {
@@ -53,7 +55,7 @@ impl Circuit<F> for TestCircuit {
                 |mut region: Region<'_, F>| config.assign_permutation(&mut region, initial_state),
             )?;
 
-            let got = format!("{:?}", join_values(final_state).inner.unwrap());
+            let got = format!("{:?}", unwrap_value(join_values(final_state)));
 
             // For input 0,1,2.
             let expect = "[0x115cc0f5e7d690413df64c6b9662e9cf2a3617f2743245519e19607a4417189a, 0x0fca49b798923ab0239de1c9e7a4a9a2210312b6a2f616d18b5a87f9b628ae29, 0x0e7ae82e40091e63cbd4f16a6d16310b3729d4b6e138fcf54110e2867045a30c]";

--- a/src/poseidon/septidon/transition_round.rs
+++ b/src/poseidon/septidon/transition_round.rs
@@ -60,7 +60,7 @@ impl TransitionRoundChip {
             input[1].clone(),
             input[2].clone(),
         ];
-        matmul::expr(&mds(), sbox_out)
+        matmul::expr(mds(), sbox_out)
     }
 
     fn round_constant<F: CachedConstants>() -> F {
@@ -104,7 +104,7 @@ impl TransitionRoundChip {
             input[1],
             input[2],
         ];
-        let output = join_values(sbox_out).map(|s| matmul::value(&mds(), s));
+        let output = join_values(sbox_out).map(|s| matmul::value(mds(), s));
         split_values(output)
     }
 

--- a/src/poseidon/septidon/transition_round.rs
+++ b/src/poseidon/septidon/transition_round.rs
@@ -53,7 +53,9 @@ impl TransitionRoundChip {
 
     // Return an expression of the state after the first partial round given the state before.
     // TODO: implement with with degree <= 5 using the helper cell.
-    fn first_partial_round_expr<F: CachedConstants>(input: &[Expression<F>; 3]) -> [Expression<F>; 3] {
+    fn first_partial_round_expr<F: CachedConstants>(
+        input: &[Expression<F>; 3],
+    ) -> [Expression<F>; 3] {
         let rc = Expression::Constant(Self::round_constant());
         let sbox_out = [
             params::sbox::expr(input[0].clone(), rc),

--- a/src/poseidon/septidon/util.rs
+++ b/src/poseidon/septidon/util.rs
@@ -14,7 +14,10 @@ where
 }
 
 /// Helper to make queries to a ConstraintSystem. Escape the "create_gate" closures.
-pub fn query<T, F:FieldExt>(cs: &mut ConstraintSystem<F>, f: impl FnOnce(&mut VirtualCells<'_, F>) -> T) -> T {
+pub fn query<T, F: FieldExt>(
+    cs: &mut ConstraintSystem<F>,
+    f: impl FnOnce(&mut VirtualCells<'_, F>) -> T,
+) -> T {
     let mut queries: Option<T> = None;
     cs.create_gate("query", |meta| {
         queries = Some(f(meta));
@@ -23,14 +26,14 @@ pub fn query<T, F:FieldExt>(cs: &mut ConstraintSystem<F>, f: impl FnOnce(&mut Vi
     queries.unwrap()
 }
 
-pub fn join_values<F:FieldExt>(values: [Value<F>; 3]) -> Value<[F; 3]> {
+pub fn join_values<F: FieldExt>(values: [Value<F>; 3]) -> Value<[F; 3]> {
     values[0]
         .zip(values[1])
         .zip(values[2])
         .map(|((v0, v1), v2)| [v0, v1, v2])
 }
 
-pub fn split_values<F:FieldExt>(values: Value<[F; 3]>) -> [Value<F>; 3] {
+pub fn split_values<F: FieldExt>(values: Value<[F; 3]>) -> [Value<F>; 3] {
     [
         values.map(|v| v[0]),
         values.map(|v| v[1]),
@@ -42,12 +45,12 @@ pub mod pow_5 {
     use super::FieldExt;
     use halo2_proofs::plonk::Expression;
 
-    pub fn expr<F:FieldExt>(v: Expression<F>) -> Expression<F> {
+    pub fn expr<F: FieldExt>(v: Expression<F>) -> Expression<F> {
         let v2 = v.clone() * v.clone();
         v2.clone() * v2 * v
     }
 
-    pub fn value<F:FieldExt>(v: F) -> F {
+    pub fn value<F: FieldExt>(v: F) -> F {
         let v2 = v * v;
         v2 * v2 * v
     }
@@ -55,13 +58,13 @@ pub mod pow_5 {
 
 /// Matrix multiplication expressions and values.
 pub mod matmul {
-    use super::FieldExt;
     use super::super::params::Mds;
+    use super::FieldExt;
     use halo2_proofs::plonk::Expression;
     use std::convert::TryInto;
 
     /// Multiply a vector of expressions by a constant matrix.
-    pub fn expr<F:FieldExt>(matrix: &Mds<F>, vector: [Expression<F>; 3]) -> [Expression<F>; 3] {
+    pub fn expr<F: FieldExt>(matrix: &Mds<F>, vector: [Expression<F>; 3]) -> [Expression<F>; 3] {
         (0..3)
             .map(|next_idx| {
                 (0..3)
@@ -75,7 +78,7 @@ pub mod matmul {
     }
 
     /// Multiply a vector of values by a constant matrix.
-    pub fn value<F:FieldExt>(matrix: &Mds<F>, vector: [F; 3]) -> [F; 3] {
+    pub fn value<F: FieldExt>(matrix: &Mds<F>, vector: [F; 3]) -> [F; 3] {
         (0..3)
             .map(|next_idx| {
                 (0..3)

--- a/src/poseidon/septidon/util.rs
+++ b/src/poseidon/septidon/util.rs
@@ -120,7 +120,7 @@ pub mod or {
     pub fn expr<F: FieldExt>(a: Expression<F>, b: Expression<F>) -> Expression<F> {
         let one = Expression::Constant(F::from(1));
         // a OR b <=> !(!a AND !b)
-        one.clone() - ((one.clone() - a) * (one.clone() - b))
+        one.clone() - ((one.clone() - a) * (one - b))
     }
 
     /// Return (a OR b), assuming a and b are boolean values.

--- a/src/poseidon/septidon/util.rs
+++ b/src/poseidon/septidon/util.rs
@@ -1,5 +1,6 @@
 use halo2_proofs::circuit::Value;
-use halo2_proofs::halo2curves::bn256::Fr as F;
+//use halo2_proofs::halo2curves::bn256::Fr as F;
+use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::plonk::{ConstraintSystem, Expression, VirtualCells};
 
 pub fn map_array<IN, OUT, FN>(array: &[IN; 3], mut f: FN) -> [OUT; 3]
@@ -13,7 +14,7 @@ where
 }
 
 /// Helper to make queries to a ConstraintSystem. Escape the "create_gate" closures.
-pub fn query<T>(cs: &mut ConstraintSystem<F>, f: impl FnOnce(&mut VirtualCells<'_, F>) -> T) -> T {
+pub fn query<T, F:FieldExt>(cs: &mut ConstraintSystem<F>, f: impl FnOnce(&mut VirtualCells<'_, F>) -> T) -> T {
     let mut queries: Option<T> = None;
     cs.create_gate("query", |meta| {
         queries = Some(f(meta));
@@ -22,14 +23,14 @@ pub fn query<T>(cs: &mut ConstraintSystem<F>, f: impl FnOnce(&mut VirtualCells<'
     queries.unwrap()
 }
 
-pub fn join_values(values: [Value<F>; 3]) -> Value<[F; 3]> {
+pub fn join_values<F:FieldExt>(values: [Value<F>; 3]) -> Value<[F; 3]> {
     values[0]
         .zip(values[1])
         .zip(values[2])
         .map(|((v0, v1), v2)| [v0, v1, v2])
 }
 
-pub fn split_values(values: Value<[F; 3]>) -> [Value<F>; 3] {
+pub fn split_values<F:FieldExt>(values: Value<[F; 3]>) -> [Value<F>; 3] {
     [
         values.map(|v| v[0]),
         values.map(|v| v[1]),
@@ -38,15 +39,15 @@ pub fn split_values(values: Value<[F; 3]>) -> [Value<F>; 3] {
 }
 
 pub mod pow_5 {
-    use super::super::params::F;
+    use super::FieldExt;
     use halo2_proofs::plonk::Expression;
 
-    pub fn expr(v: Expression<F>) -> Expression<F> {
+    pub fn expr<F:FieldExt>(v: Expression<F>) -> Expression<F> {
         let v2 = v.clone() * v.clone();
         v2.clone() * v2 * v
     }
 
-    pub fn value(v: F) -> F {
+    pub fn value<F:FieldExt>(v: F) -> F {
         let v2 = v * v;
         v2 * v2 * v
     }
@@ -54,12 +55,13 @@ pub mod pow_5 {
 
 /// Matrix multiplication expressions and values.
 pub mod matmul {
-    use super::super::params::{Mds, F};
+    use super::FieldExt;
+    use super::super::params::Mds;
     use halo2_proofs::plonk::Expression;
     use std::convert::TryInto;
 
     /// Multiply a vector of expressions by a constant matrix.
-    pub fn expr(matrix: &Mds, vector: [Expression<F>; 3]) -> [Expression<F>; 3] {
+    pub fn expr<F:FieldExt>(matrix: &Mds<F>, vector: [Expression<F>; 3]) -> [Expression<F>; 3] {
         (0..3)
             .map(|next_idx| {
                 (0..3)
@@ -73,7 +75,7 @@ pub mod matmul {
     }
 
     /// Multiply a vector of values by a constant matrix.
-    pub fn value(matrix: &Mds, vector: [F; 3]) -> [F; 3] {
+    pub fn value<F:FieldExt>(matrix: &Mds<F>, vector: [F; 3]) -> [F; 3] {
         (0..3)
             .map(|next_idx| {
                 (0..3)

--- a/tests/hash_proving.rs
+++ b/tests/hash_proving.rs
@@ -79,13 +79,16 @@ fn hash_circuit() {
 
 #[test]
 fn vk_validity() {
+    use halo2_proofs::SerdeFormat;
+
     let params = Params::<Bn256>::unsafe_setup(8);
 
     let circuit = TestCircuit(PoseidonHashTable::default(), 3);
     let vk1 = keygen_vk(&params, &circuit).unwrap();
 
     let mut vk1_buf: Vec<u8> = Vec::new();
-    vk1.write(&mut vk1_buf).unwrap();
+    vk1.write(&mut vk1_buf, SerdeFormat::RawBytesUnchecked)
+        .unwrap();
 
     let circuit = TestCircuit(
         PoseidonHashTable {
@@ -106,7 +109,8 @@ fn vk_validity() {
     let vk2 = keygen_vk(&params, &circuit).unwrap();
 
     let mut vk2_buf: Vec<u8> = Vec::new();
-    vk2.write(&mut vk2_buf).unwrap();
+    vk2.write(&mut vk2_buf, SerdeFormat::RawBytesUnchecked)
+        .unwrap();
 
     assert_eq!(vk1_buf, vk2_buf);
 }


### PR DESCRIPTION
Current the code (`SpongeChip`) under "short" feature (i.e. septidon is applied) can not be wrapped into mpt and zkevm circuits for lacking of the generic on field. Notice the external caller consider poseidon circuit is generic by field with `Hashable` trait as constraints, we can not specializate it to bn254's field type too early.

Here we have launched a wide range refactoring with noticing the original `Hashable` trait is not enough for sepctidon, since it require a 'cached' permutation constants being provided. We have to switch the `Hashable` trait by different feature (from the original `P128pow5t3` to extended `CachedConstant`), and update most of the septidon code with a field generic.