### PR TITLE
feat: use assign_regions api to speed up the witness assignment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_09_10" }
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_09_10", features=["parallel_syn"] }
 lazy_static = "1.4.0"
 thiserror = "1.0"
 bitvec = "1"
@@ -14,7 +14,7 @@ rand_xorshift = "0.3.0"
 rand = "0.8"
 
 [patch."https://github.com/privacy-scaling-explorations/halo2.git"]
-halo2_proofs = { git = "https://github.com/scroll-tech/halo2.git", branch = "scroll-dev-0220" }
+halo2_proofs = { git = "https://github.com/scroll-tech/halo2.git", branch = "scroll-dev-0220", features=["parallel_syn"] }
 
 [features]
 # Use an implementation using fewer rows (8) per permutation.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-halo2_proofs = { git = "https://github.com/scroll-tech/halo2.git", branch = "scroll-dev-0220" }
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_09_10" }
 lazy_static = "1.4.0"
 thiserror = "1.0"
 bitvec = "1"
+log = "0.4.0"
 rand_xorshift = "0.3.0"
 rand = "0.8"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.gi
 lazy_static = "1.4.0"
 thiserror = "1.0"
 bitvec = "1"
+rand_xorshift = "0.3.0"
+rand = "0.8"
 
 [patch."https://github.com/privacy-scaling-explorations/halo2.git"]
 halo2_proofs = { git = "https://github.com/scroll-tech/halo2.git", branch = "scroll-dev-0220" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_09_10", features=["parallel_syn"] }
+halo2_proofs = { git = "https://github.com/scroll-tech/halo2.git", branch = "scroll-dev-0220" }
 lazy_static = "1.4.0"
 thiserror = "1.0"
 bitvec = "1"
@@ -14,9 +14,10 @@ rand_xorshift = "0.3.0"
 rand = "0.8"
 
 [patch."https://github.com/privacy-scaling-explorations/halo2.git"]
-halo2_proofs = { git = "https://github.com/scroll-tech/halo2.git", branch = "scroll-dev-0220", features=["parallel_syn"] }
+halo2_proofs = { git = "https://github.com/scroll-tech/halo2.git", branch = "scroll-dev-0220" }
 
 [features]
+default = ["halo2_proofs/parallel_syn"]
 # Use an implementation using fewer rows (8) per permutation.
 short = []
 # printout the layout of circuits for demo and some unittests

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -374,7 +374,10 @@ impl<F: Hashable> PoseidonHashTable<F> {
 
 /// Represent the chip for Poseidon hash table
 #[derive(Debug)]
-pub struct SpongeChip<'d, F: FieldExt, const STEP: usize, PC: Chip<F> + Clone + DebugT> {
+pub struct SpongeChip<'d, F: FieldExt, const STEP: usize, PC: Chip<F> + Clone + DebugT>
+where
+    PC::Config: Sync,
+{
     calcs: usize,
     nil_msg_hash: Option<F>,
     mpt_only: bool,
@@ -387,6 +390,8 @@ type PermutedStatePair<Word> = (PermutedState<Word>, PermutedState<Word>);
 
 impl<'d, F: Hashable, const STEP: usize, PC: PermuteChip<F, F::SpecType, 3, 2>>
     SpongeChip<'d, F, STEP, PC>
+where
+    PC::Config: Sync,
 {
     ///construct the chip
     pub fn construct(
@@ -705,6 +710,8 @@ impl<'d, F: Hashable, const STEP: usize, PC: PermuteChip<F, F::SpecType, 3, 2>>
 
 impl<F: FieldExt, const STEP: usize, PC: Chip<F> + Clone + DebugT> Chip<F>
     for SpongeChip<'_, F, STEP, PC>
+where
+    PC::Config: Sync,
 {
     type Config = SpongeConfig<F, PC>;
     type Loaded = PoseidonHashTable<F>;
@@ -799,7 +806,10 @@ mod tests {
         }
     }
 
-    impl<PC: PermuteChip<Fr, <Fr as Hashable>::SpecType, 3, 2>> Circuit<Fr> for TestCircuit<PC> {
+    impl<PC: PermuteChip<Fr, <Fr as Hashable>::SpecType, 3, 2>> Circuit<Fr> for TestCircuit<PC>
+    where
+        PC::Config: Sync,
+    {
         type Config = (SpongeConfig<Fr, PC>, usize);
         type FloorPlanner = SimpleFloorPlanner;
 
@@ -870,7 +880,10 @@ mod tests {
         poseidon_hash_circuit_impl::<SeptidonChip>();
     }
 
-    fn poseidon_hash_circuit_impl<PC: PermuteChip<Fr, <Fr as Hashable>::SpecType, 3, 2>>() {
+    fn poseidon_hash_circuit_impl<PC: PermuteChip<Fr, <Fr as Hashable>::SpecType, 3, 2>>()
+    where
+        PC::Config: Sync,
+    {
         let message1 = [
             Fr::from_str_vartime("1").unwrap(),
             Fr::from_str_vartime("2").unwrap(),
@@ -896,7 +909,10 @@ mod tests {
         poseidon_var_len_hash_circuit_impl::<SeptidonChip>();
     }
 
-    fn poseidon_var_len_hash_circuit_impl<PC: PermuteChip<Fr, <Fr as Hashable>::SpecType, 3, 2>>() {
+    fn poseidon_var_len_hash_circuit_impl<PC: PermuteChip<Fr, <Fr as Hashable>::SpecType, 3, 2>>()
+    where
+        PC::Config: Sync,
+    {
         use rand::SeedableRng;
         use rand_xorshift::XorShiftRng;
 

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -652,11 +652,14 @@ impl<'d, F: Hashable, const STEP: usize, PC: PermuteChip<F, F::SpecType, 3, 2>>
             },
         )?;
 
+        layouter.assign_region(|| "hash table custom", |mut region| {
+            self.fill_hash_tbl_custom(&mut region)
+        })?;
+
         let (states_in, states_out) = layouter.assign_region(
             || "hash table",
             |mut region| {
-                let offset = self.fill_hash_tbl_custom(&mut region)?;
-                self.fill_hash_tbl_body(&mut region, offset)
+                self.fill_hash_tbl_body(&mut region, 0)
             },
         )?;
 

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -450,7 +450,7 @@ where
         for (i, ((inp, control), check)) in inputs_i.zip(controls_i).zip(checks_i).enumerate() {
             let control = control.copied().unwrap_or(0);
             let offset = i + begin_offset;
-            let last_offset = offset;
+            last_offset = offset;
 
             let control_as_flag = F::from_u128(control as u128 * HASHABLE_DOMAIN_SPEC);
 
@@ -879,16 +879,10 @@ where
             (states_in, states_out)
         };
 
-        let mut chip_finals = Vec::new();
-        for state in states_in {
-            let chip = PC::construct(config.permute_config.clone());
-
-            let final_state = <PC as PoseidonInstructions<F, F::SpecType, 3, 2>>::permute(
-                &chip, layouter, &state,
-            )?;
-
-            chip_finals.push(final_state);
-        }
+        let chip = PC::construct(config.permute_config.clone());
+        let chip_finals = <PC as PoseidonInstructions<F, F::SpecType, 3, 2>>::permute_batch(
+            &chip, layouter, &states_in,
+        )?;
 
         layouter.assign_region(
             || "final state dummy",

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -853,7 +853,7 @@ where
             let chunks_count = std::thread::available_parallelism()
                 .map(|e| e.get())
                 .unwrap_or(32);
-            let min_len = self.calcs / chunks_count;
+            let min_len = self.calcs / chunks_count + 1;
             let mut chunk_len = 0;
 
             let data: Vec<((Option<&[F; 2]>, Option<&u64>), Option<&F>)> =

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -410,6 +410,171 @@ where
         }
     }
 
+    fn fill_hash_tbl_body(
+        &self,
+        region: &mut Region<'_, F>,
+        begin_offset: usize,
+    ) -> Result<PermutedStatePair<PC::Word>, Error> {
+        let config = &self.config;
+        let data = self.data;
+
+        let mut states_in = Vec::new();
+        let mut states_out = Vec::new();
+        let hash_helper = F::hasher();
+
+        let inputs_i = data
+            .inputs
+            .iter()
+            .map(Some)
+            .chain(std::iter::repeat(None))
+            .take(self.calcs);
+        let controls_i = data
+            .controls
+            .iter()
+            .map(Some)
+            .chain(std::iter::repeat(None))
+            .take(self.calcs);
+
+        let checks_i = data
+            .checks
+            .iter()
+            .map(|i| i.as_ref())
+            .chain(std::iter::repeat(None))
+            .take(self.calcs);
+
+        let mut is_new_sponge = true;
+        let mut process_start = 0;
+        let mut state: [F; 3] = [F::zero(); 3];
+        let mut last_offset = 0;
+
+        for (i, ((inp, control), check)) in inputs_i.zip(controls_i).zip(checks_i).enumerate() {
+            let control = control.copied().unwrap_or(0);
+            let offset = i + begin_offset;
+            last_offset = offset;
+
+            let control_as_flag = F::from_u128(control as u128 * HASHABLE_DOMAIN_SPEC);
+
+            if is_new_sponge {
+                state[0] = control_as_flag;
+                process_start = offset;
+            }
+
+            let inp = inp
+                .map(|[a, b]| [*a, *b])
+                .unwrap_or_else(|| [F::zero(), F::zero()]);
+
+            state.iter_mut().skip(1).zip(inp).for_each(|(s, inp)| {
+                if is_new_sponge {
+                    *s = inp;
+                } else {
+                    *s += inp;
+                }
+            });
+
+            let state_start = state;
+            hash_helper.permute(&mut state); //here we calculate the hash
+
+            //and sanity check ...
+            if let Some(ck) = check {
+                assert_eq!(
+                    *ck, state[0],
+                    "hash output not match with expected at {offset}"
+                );
+            }
+
+            let current_hash = state[0];
+
+            //assignment ...
+            region.assign_fixed(
+                || "assign q_enable",
+                self.config.q_enable,
+                offset,
+                || Value::known(F::one()),
+            )?;
+
+            let c_start = [0; 3]
+                .into_iter()
+                .enumerate()
+                .map(|(i, _)| {
+                    region.assign_advice(
+                        || format!("state input {i}_{offset}"),
+                        config.hash_table_aux[i],
+                        offset,
+                        || Value::known(state_start[i]),
+                    )
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            let c_end = [5, 3, 4]
+                .into_iter()
+                .enumerate()
+                .map(|(i, j)| {
+                    region.assign_advice(
+                        || format!("state output {i}_{offset}"),
+                        config.hash_table_aux[j],
+                        offset,
+                        || Value::known(state[i]),
+                    )
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            for (tip, col, val) in [
+                ("hash input first", config.hash_table[1], inp[0]),
+                ("hash input second", config.hash_table[2], inp[1]),
+                ("state input control", config.hash_table[3], control_as_flag),
+                (
+                    "state beginning flag",
+                    config.hash_table[4],
+                    if is_new_sponge { F::one() } else { F::zero() },
+                ),
+                (
+                    "state input control_aux",
+                    config.control_aux,
+                    control_as_flag.invert().unwrap_or_else(F::zero),
+                ),
+                (
+                    "state continue control",
+                    config.s_sponge_continue,
+                    if is_new_sponge { F::zero() } else { F::one() },
+                ),
+            ] {
+                region.assign_advice(
+                    || format!("{tip}_{offset}"),
+                    col,
+                    offset,
+                    || Value::known(val),
+                )?;
+            }
+
+            is_new_sponge = control <= STEP as u64;
+
+            //fill all the hash_table[0] with result hash
+            if is_new_sponge {
+                (process_start..=offset).try_for_each(|ith| {
+                    region
+                        .assign_advice(
+                            || format!("hash index_{ith}"),
+                            config.hash_table[0],
+                            ith,
+                            || Value::known(current_hash),
+                        )
+                        .map(|_| ())
+                })?;
+            }
+
+            //we directly specify the init state of permutation
+            let c_start_arr: [_; 3] = c_start.try_into().expect("same size");
+            states_in.push(c_start_arr.map(PC::Word::from));
+            let c_end_arr: [_; 3] = c_end.try_into().expect("same size");
+            states_out.push(c_end_arr.map(PC::Word::from));
+        }
+
+        // set the last row is "custom", a row both enabled and customed
+        // can only fill a padding row ([0, 0] in MPT mode)
+        config.s_custom.enable(region, last_offset)?;
+        Ok((states_in, states_out))
+    }
+
     fn fill_hash_tbl_custom(&self, region: &mut Region<'_, F>) -> Result<usize, Error> {
         let config = &self.config;
 
@@ -624,56 +789,68 @@ where
             },
         )?;
 
-        layouter.assign_region(
-            || "hash table custom",
-            |mut region| self.fill_hash_tbl_custom(&mut region),
-        )?;
+        let assignment_type = std::env::var("ASSIGNMENT_TYPE").unwrap_or("default".into());
+        let (states_in, states_out) = if assignment_type == "default" {
+            layouter.assign_region(
+                || "hash table",
+                |mut region| {
+                    let offset = self.fill_hash_tbl_custom(&mut region)?;
+                    self.fill_hash_tbl_body(&mut region, offset)
+                },
+            )?
+        } else {
+            layouter.assign_region(
+                || "hash table custom",
+                |mut region| self.fill_hash_tbl_custom(&mut region),
+            )?;
 
-        let data = self.data;
+            let data = self.data;
 
-        let inputs_i = data
-            .inputs
-            .iter()
-            .map(Some)
-            .chain(std::iter::repeat(None))
-            .take(self.calcs);
-        let controls_i = data
-            .controls
-            .iter()
-            .map(Some)
-            .chain(std::iter::repeat(None))
-            .take(self.calcs);
+            let inputs_i = data
+                .inputs
+                .iter()
+                .map(Some)
+                .chain(std::iter::repeat(None))
+                .take(self.calcs);
+            let controls_i = data
+                .controls
+                .iter()
+                .map(Some)
+                .chain(std::iter::repeat(None))
+                .take(self.calcs);
 
-        let checks_i = data
-            .checks
-            .iter()
-            .map(|i| i.as_ref())
-            .chain(std::iter::repeat(None))
-            .take(self.calcs);
+            let checks_i = data
+                .checks
+                .iter()
+                .map(|i| i.as_ref())
+                .chain(std::iter::repeat(None))
+                .take(self.calcs);
 
-        let data: Vec<(usize, ((Option<&[F; 2]>, Option<&u64>), Option<&F>))> =
-            inputs_i.zip(controls_i).zip(checks_i).enumerate().collect();
-        let assignments = data
-            .group_by(|(_, ((_, control), _)), _| control.copied().unwrap_or(0) > STEP as u64)
-            .map(|data| {
-                |mut region: Region<'_, F>| -> Result<PermutedStatePair<PC::Word>, Error> {
-                    self.fill_hash_tbl_body_sponge(&mut region, data)
-                }
-            })
-            .collect::<Vec<_>>();
+            let data: Vec<(usize, ((Option<&[F; 2]>, Option<&u64>), Option<&F>))> =
+                inputs_i.zip(controls_i).zip(checks_i).enumerate().collect();
+            let assignments = data
+                .group_by(|(_, ((_, control), _)), _| control.copied().unwrap_or(0) > STEP as u64)
+                .map(|data| {
+                    |mut region: Region<'_, F>| -> Result<PermutedStatePair<PC::Word>, Error> {
+                        self.fill_hash_tbl_body_sponge(&mut region, data)
+                    }
+                })
+                .collect::<Vec<_>>();
 
-        let ret = layouter.assign_regions(|| "hash table", assignments)?;
-        layouter.assign_region(
-            || "enable hash table custom",
-            |mut region| self.config.s_custom.enable(&mut region, self.calcs),
-        )?;
+            let ret = layouter.assign_regions(|| "hash table", assignments)?;
+            layouter.assign_region(
+                || "enable hash table custom",
+                |mut region| self.config.s_custom.enable(&mut region, self.calcs),
+            )?;
 
-        let mut states_in = vec![];
-        let mut states_out = vec![];
-        for (s_in, s_out) in ret.into_iter() {
-            states_in.extend(s_in);
-            states_out.extend(s_out);
-        }
+            let mut states_in = vec![];
+            let mut states_out = vec![];
+            for (s_in, s_out) in ret.into_iter() {
+                states_in.extend(s_in);
+                states_out.extend(s_out);
+            }
+            (states_in, states_out)
+        };
 
         let mut chip_finals = Vec::new();
         for state in states_in {
@@ -730,7 +907,7 @@ mod tests {
     use super::*;
     use halo2_proofs::halo2curves::bn256::{Bn256, G1Affine};
     use halo2_proofs::halo2curves::group::ff::PrimeField;
-    use halo2_proofs::plonk::{create_proof, keygen_pk, keygen_vk, verify_proof};
+    use halo2_proofs::plonk::{create_proof, keygen_pk, keygen_pk2, keygen_vk, verify_proof};
     use halo2_proofs::poly::commitment::ParamsProver;
     use halo2_proofs::poly::kzg::commitment::{KZGCommitmentScheme, ParamsKZG, ParamsVerifierKZG};
     use halo2_proofs::poly::kzg::multiopen::{ProverSHPLONK, VerifierSHPLONK};
@@ -935,8 +1112,9 @@ mod tests {
             //checks: vec![None, Some(Fr::from_str_vartime("15002881182751877599173281392790087382867290792048832034781070831698029191486").unwrap())],
             ..Default::default()
         });
-        let vk = keygen_vk(&general_params, &circuit).expect("keygen_vk shouldn't fail");
-        let pk = keygen_pk(&general_params, vk, &circuit).expect("keygen_pk shouldn't fail");
+
+        std::env::set_var("ASSIGNMENT_TYPE", "default");
+        let pk = keygen_pk2(&general_params, &circuit).expect("keygen_pk shouldn't fail");
 
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
         create_proof::<
@@ -959,6 +1137,7 @@ mod tests {
 
         let mut verifier_transcript = Blake2bRead::<_, G1Affine, Challenge255<_>>::init(&proof[..]);
         let strategy = SingleStrategy::new(&general_params);
+        std::env::set_var("ASSIGNMENT_TYPE", "parallel");
         verify_proof::<
             KZGCommitmentScheme<Bn256>,
             VerifierSHPLONK<'_, Bn256>,

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1157,7 +1157,7 @@ mod tests {
         std::env::set_var("ASSIGNMENT_TYPE", "default");
         let pk = keygen_pk2(&general_params, &circuit).expect("keygen_pk shouldn't fail");
 
-        std::env::set_var("ASSIGNMENT_TYPE", "default");
+        std::env::set_var("ASSIGNMENT_TYPE", "parallel");
         let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
         create_proof::<
             KZGCommitmentScheme<Bn256>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! mpt demo circuits
 //
 
+#![feature(slice_group_by)]
 #![allow(dead_code)]
 #![allow(unused_macros)]
 #![deny(missing_docs)]

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -45,7 +45,7 @@ pub trait PoseidonInstructions<F: FieldExt, S: Spec<F, T, RATE>, const T: usize,
     Chip<F>
 {
     /// Variable representing the word over which the Poseidon permutation operates.
-    type Word: Clone + fmt::Debug + From<AssignedCell<F, F>> + Into<AssignedCell<F, F>>;
+    type Word: Clone + fmt::Debug + From<AssignedCell<F, F>> + Into<AssignedCell<F, F>> + Sync;
 
     /// Applies the Poseidon permutation to the given state.
     fn permute(

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -45,7 +45,7 @@ pub trait PoseidonInstructions<F: FieldExt, S: Spec<F, T, RATE>, const T: usize,
     Chip<F>
 {
     /// Variable representing the word over which the Poseidon permutation operates.
-    type Word: Clone + fmt::Debug + From<AssignedCell<F, F>> + Into<AssignedCell<F, F>> + Sync;
+    type Word: Clone + fmt::Debug + From<AssignedCell<F, F>> + Into<AssignedCell<F, F>> + Send;
 
     /// Applies the Poseidon permutation to the given state.
     fn permute(

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -45,7 +45,7 @@ pub trait PoseidonInstructions<F: FieldExt, S: Spec<F, T, RATE>, const T: usize,
     Chip<F>
 {
     /// Variable representing the word over which the Poseidon permutation operates.
-    type Word: Clone + fmt::Debug + From<AssignedCell<F, F>> + Into<AssignedCell<F, F>> + Send;
+    type Word: Clone + fmt::Debug + From<AssignedCell<F, F>> + Into<AssignedCell<F, F>> + Send + Sync;
 
     /// Applies the Poseidon permutation to the given state.
     fn permute(

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -51,8 +51,17 @@ pub trait PoseidonInstructions<F: FieldExt, S: Spec<F, T, RATE>, const T: usize,
     fn permute(
         &self,
         layouter: &mut impl Layouter<F>,
-        initial_state: &State<Self::Word, T>,
+        initial_states: &State<Self::Word, T>,
     ) -> Result<State<Self::Word, T>, Error>;
+
+    /// Applies the Poseidon permutation to the given states.
+    fn permute_batch(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        initial_states: &[State<Self::Word, T>],
+    ) -> Result<Vec<State<Self::Word, T>>, Error> {
+        initial_states.iter().map(|initial_state| self.permute(layouter, initial_state)).collect::<Result<Vec<_>, Error>>()
+    }
 }
 
 /// The set of circuit instructions required to use the [`Sponge`] and [`Hash`] gadgets.

--- a/src/poseidon/septidon/control.rs
+++ b/src/poseidon/septidon/control.rs
@@ -43,8 +43,8 @@ impl ControlChip {
     }
 
     /// Assign the fixed positions of the last row of permutations.
-    pub fn assign<F: FieldExt>(&self, region: &mut Region<'_, F>) -> Result<(), Error> {
-        region.assign_fixed(|| "", self.is_last, 7, || Value::known(F::one()))?;
+    pub fn assign<F: FieldExt>(&self, region: &mut Region<'_, F>, begin_offset: usize) -> Result<(), Error> {
+        region.assign_fixed(|| "", self.is_last, 7 + begin_offset, || Value::known(F::one()))?;
         Ok(())
     }
 

--- a/src/poseidon/septidon/control.rs
+++ b/src/poseidon/septidon/control.rs
@@ -42,8 +42,13 @@ impl ControlChip {
         (chip, signals)
     }
 
+    /// Assign the fixed positions of the last row of permutations for a new region.
+    pub fn assign<F: FieldExt>(&self, region: &mut Region<'_, F>) -> Result<(), Error> {
+        self.assign_with_offset(region, 0)
+    }
+
     /// Assign the fixed positions of the last row of permutations.
-    pub fn assign<F: FieldExt>(&self, region: &mut Region<'_, F>, begin_offset: usize) -> Result<(), Error> {
+    pub fn assign_with_offset<F: FieldExt>(&self, region: &mut Region<'_, F>, begin_offset: usize) -> Result<(), Error> {
         region.assign_fixed(|| "", self.is_last, 7 + begin_offset, || Value::known(F::one()))?;
         Ok(())
     }

--- a/src/poseidon/septidon/instruction.rs
+++ b/src/poseidon/septidon/instruction.rs
@@ -87,44 +87,99 @@ impl<F: CachedConstants, S: Spec<F, WIDTH, RATE>> PoseidonInstructions<F, S, WID
         layouter: &mut impl Layouter<F>,
         initial_states: &[State<Self::Word, WIDTH>],
     ) -> Result<Vec<State<Self::Word, WIDTH>>, Error> {
-        let assignments = initial_states.iter().map(|initial_state| {
-            |mut region: Region<'_, F>| -> Result<State<Self::Word, WIDTH>, Error> {
+        layouter.assign_region(
+            || "permute state",
+            |mut region| {
                 let region = &mut region;
+                let mut final_states = vec![];
+                let mut last_offset = 0;
 
-                // Copy the given initial_state into the permutation chip.
-                let chip_input = self.initial_state_cells();
-                for i in 0..WIDTH {
-                    initial_state[i].0.copy_advice(
-                        || format!("load state_{i}"),
-                        region,
-                        chip_input[i].column,
-                        chip_input[i].offset as usize,
-                    )?;
+                for initial_state in initial_states.iter() {
+                    // Copy the given initial_state into the permutation chip.
+                    let chip_input = self.initial_state_cells();
+                    for i in 0..WIDTH {
+                        initial_state[i].0.copy_advice(
+                            || format!("load state_{i}"),
+                            region,
+                            chip_input[i].column,
+                            last_offset + chip_input[i].offset as usize,
+                        )?;
+                    }
+
+                    // Assign the internal witness of the permutation.
+                    let initial_values = map_array(initial_state, |word| word.value());
+                    let final_values = self.assign_permutation(region, initial_values)?;
+
+                    // Return the cells containing the final state.
+                    let chip_output = self.final_state_cells();
+                    let final_state: Vec<StateWord<F>> = (0..WIDTH)
+                        .map(|i| {
+                            region
+                                .assign_advice(
+                                    || format!("output {i}"),
+                                    chip_output[i].column,
+                                    last_offset + chip_output[i].offset as usize,
+                                    || final_values[i],
+                                )
+                                .map(StateWord)
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+
+                    last_offset += 8;
+                    final_states.push(final_state.try_into().unwrap());
                 }
+                Ok(final_states)
+            },
+        )
+        // let chunks_count = std::thread::available_parallelism()
+        //     .map(|e| e.get())
+        //     .unwrap_or(32);
+        // let chunks_len = initial_states.len() / chunks_count + 2;
+        // println!("chunks_len: {}", chunks_len);
 
-                // Assign the internal witness of the permutation.
-                let initial_values = map_array(initial_state, |word| word.value());
-                let final_values = self.assign_permutation(region, initial_values)?;
+        // let assignments = initial_states.chunks(chunks_len).map(|initial_states| {
+        //     |mut region: Region<'_, F>| -> Result<Vec<State<Self::Word, WIDTH>>, Error> {
+        //         let mut final_state = vec![];
+        //         let mut last_offset = 0usize;
+        //         for initial_state in initial_states.iter() {
+        //             let region = &mut region;
 
-                // Return the cells containing the final state.
-                let chip_output = self.final_state_cells();
-                let final_state: Vec<StateWord<F>> = (0..WIDTH)
-                    .map(|i| {
-                        region
-                            .assign_advice(
-                                || format!("output {i}"),
-                                chip_output[i].column,
-                                chip_output[i].offset as usize,
-                                || final_values[i],
-                            )
-                            .map(StateWord)
-                    })
-                    .collect::<Result<Vec<_>, _>>()?;
+        //             // Copy the given initial_state into the permutation chip.
+        //             let chip_input = self.initial_state_cells();
+        //             for i in 0..WIDTH {
+        //                 initial_state[i].0.copy_advice(
+        //                     || format!("load state_{i}"),
+        //                     region,
+        //                     chip_input[i].column,
+        //                     last_offset + chip_input[i].offset as usize,
+        //                 )?;
+        //             }
 
-                Ok(final_state.try_into().unwrap())
-            }
-        }).collect::<Vec<_>>();
-        layouter.assign_regions(|| "permute state", assignments)
+        //             // Assign the internal witness of the permutation.
+        //             let initial_values = map_array(initial_state, |word| word.value());
+        //             let final_values = self.assign_permutation(region, initial_values)?;
+
+        //             // Return the cells containing the final state.
+        //             let chip_output = self.final_state_cells();
+        //             let state: Vec<StateWord<F>> = (0..WIDTH)
+        //                 .map(|i| {
+        //                     region
+        //                         .assign_advice(
+        //                             || format!("output {i}"),
+        //                             chip_output[i].column,
+        //                             last_offset + chip_output[i].offset as usize,
+        //                             || final_values[i],
+        //                         )
+        //                         .map(StateWord)
+        //                 })
+        //                 .collect::<Result<Vec<_>, _>>()?;
+        //             last_offset += 7;
+        //             final_state.push(state.try_into().unwrap())
+        //         }
+        //         Ok(final_state)
+        //     }
+        // }).collect::<Vec<_>>();
+        // layouter.assign_regions(|| "permute state", assignments).map(|e| e.into_iter().flatten().collect::<Vec<_>>())
     }
 }
 

--- a/src/poseidon/septidon/instruction.rs
+++ b/src/poseidon/septidon/instruction.rs
@@ -102,8 +102,8 @@ impl<F: CachedConstants, S: Spec<F, WIDTH, RATE>> PoseidonInstructions<F, S, WID
                 if is_first_pass {
                     is_first_pass = false;
                     let col = self.final_state_cells().first().unwrap().column;
-                    region.assign_advice(|| "First pass dummy assign", col, initial_states.len() * 8, || Value::known(F::zero()))?;
-                    return Ok(vec![]);
+                    region.assign_advice(|| "First pass dummy assign", col, initial_states.len() * 8 - 1, || Value::known(F::zero()))?;
+                    return Ok(final_states);
                 }
 
                 for initial_state in initial_states.iter() {

--- a/src/poseidon/septidon/instruction.rs
+++ b/src/poseidon/septidon/instruction.rs
@@ -60,7 +60,7 @@ impl<F: CachedConstants, S: Spec<F, WIDTH, RATE>> PoseidonInstructions<F, S, WID
 
                 // Assign the internal witness of the permutation.
                 let initial_values = map_array(initial_state, |word| word.value());
-                let final_values = self.assign_permutation(region, initial_values)?;
+                let final_values = self.assign_permutation(region, initial_values, 0)?;
 
                 // Return the cells containing the final state.
                 let chip_output = self.final_state_cells();
@@ -87,9 +87,13 @@ impl<F: CachedConstants, S: Spec<F, WIDTH, RATE>> PoseidonInstructions<F, S, WID
         layouter: &mut impl Layouter<F>,
         initial_states: &[State<Self::Word, WIDTH>],
     ) -> Result<Vec<State<Self::Word, WIDTH>>, Error> {
-        layouter.assign_region(
-            || "permute state",
-            |mut region| {
+        let chunks_count = std::thread::available_parallelism()
+            .map(|e| e.get())
+            .unwrap_or(32);
+        let chunks_len = initial_states.len() / chunks_count + 2;
+
+        let assignments = initial_states.chunks(chunks_len).map(|initial_states| {
+            |mut region: Region<'_, F>| -> Result<Vec<State<Self::Word, WIDTH>>, Error> {
                 let region = &mut region;
                 let mut final_states = vec![];
                 let mut last_offset = 0;
@@ -108,7 +112,7 @@ impl<F: CachedConstants, S: Spec<F, WIDTH, RATE>> PoseidonInstructions<F, S, WID
 
                     // Assign the internal witness of the permutation.
                     let initial_values = map_array(initial_state, |word| word.value());
-                    let final_values = self.assign_permutation(region, initial_values)?;
+                    let final_values = self.assign_permutation(region, initial_values, last_offset)?;
 
                     // Return the cells containing the final state.
                     let chip_output = self.final_state_cells();
@@ -129,57 +133,9 @@ impl<F: CachedConstants, S: Spec<F, WIDTH, RATE>> PoseidonInstructions<F, S, WID
                     final_states.push(final_state.try_into().unwrap());
                 }
                 Ok(final_states)
-            },
-        )
-        // let chunks_count = std::thread::available_parallelism()
-        //     .map(|e| e.get())
-        //     .unwrap_or(32);
-        // let chunks_len = initial_states.len() / chunks_count + 2;
-        // println!("chunks_len: {}", chunks_len);
-
-        // let assignments = initial_states.chunks(chunks_len).map(|initial_states| {
-        //     |mut region: Region<'_, F>| -> Result<Vec<State<Self::Word, WIDTH>>, Error> {
-        //         let mut final_state = vec![];
-        //         let mut last_offset = 0usize;
-        //         for initial_state in initial_states.iter() {
-        //             let region = &mut region;
-
-        //             // Copy the given initial_state into the permutation chip.
-        //             let chip_input = self.initial_state_cells();
-        //             for i in 0..WIDTH {
-        //                 initial_state[i].0.copy_advice(
-        //                     || format!("load state_{i}"),
-        //                     region,
-        //                     chip_input[i].column,
-        //                     last_offset + chip_input[i].offset as usize,
-        //                 )?;
-        //             }
-
-        //             // Assign the internal witness of the permutation.
-        //             let initial_values = map_array(initial_state, |word| word.value());
-        //             let final_values = self.assign_permutation(region, initial_values)?;
-
-        //             // Return the cells containing the final state.
-        //             let chip_output = self.final_state_cells();
-        //             let state: Vec<StateWord<F>> = (0..WIDTH)
-        //                 .map(|i| {
-        //                     region
-        //                         .assign_advice(
-        //                             || format!("output {i}"),
-        //                             chip_output[i].column,
-        //                             last_offset + chip_output[i].offset as usize,
-        //                             || final_values[i],
-        //                         )
-        //                         .map(StateWord)
-        //                 })
-        //                 .collect::<Result<Vec<_>, _>>()?;
-        //             last_offset += 7;
-        //             final_state.push(state.try_into().unwrap())
-        //         }
-        //         Ok(final_state)
-        //     }
-        // }).collect::<Vec<_>>();
-        // layouter.assign_regions(|| "permute state", assignments).map(|e| e.into_iter().flatten().collect::<Vec<_>>())
+            }
+        }).collect::<Vec<_>>();
+        layouter.assign_regions(|| "permute state", assignments).map(|e| e.into_iter().flatten().collect::<Vec<_>>())
     }
 }
 

--- a/src/poseidon/septidon/instruction.rs
+++ b/src/poseidon/septidon/instruction.rs
@@ -60,7 +60,7 @@ impl<F: CachedConstants, S: Spec<F, WIDTH, RATE>> PoseidonInstructions<F, S, WID
 
                 // Assign the internal witness of the permutation.
                 let initial_values = map_array(initial_state, |word| word.value());
-                let final_values = self.assign_permutation(region, initial_values, 0)?;
+                let final_values = self.assign_permutation(region, initial_values)?;
 
                 // Return the cells containing the final state.
                 let chip_output = self.final_state_cells();
@@ -112,7 +112,7 @@ impl<F: CachedConstants, S: Spec<F, WIDTH, RATE>> PoseidonInstructions<F, S, WID
 
                     // Assign the internal witness of the permutation.
                     let initial_values = map_array(initial_state, |word| word.value());
-                    let final_values = self.assign_permutation(region, initial_values, last_offset)?;
+                    let final_values = self.assign_permutation_with_offset(region, initial_values, last_offset)?;
 
                     // Return the cells containing the final state.
                     let chip_output = self.final_state_cells();

--- a/src/poseidon/septidon/septidon_chip.rs
+++ b/src/poseidon/septidon/septidon_chip.rs
@@ -117,8 +117,9 @@ impl SeptidonChip {
         &self,
         region: &mut Region<'_, F>,
         initial_state: [Value<F>; 3],
+        begin_offset: usize,
     ) -> Result<[Value<F>; 3], Error> {
-        self.control_chip.assign(region)?;
+        self.control_chip.assign(region, begin_offset)?;
 
         let mut state = initial_state;
 
@@ -126,7 +127,7 @@ impl SeptidonChip {
         for offset in 0..4 {
             state = self
                 .full_round_chip
-                .assign(region, offset, round_constant(offset), state)?;
+                .assign(region, offset + begin_offset, round_constant(offset), state)?;
         }
 
         // First partial round.
@@ -134,7 +135,7 @@ impl SeptidonChip {
         let middle_offset = 3;
         state = self
             .transition_chip
-            .assign_first_partial_state(region, middle_offset, state)?;
+            .assign_first_partial_state(region, middle_offset + begin_offset, state)?;
 
         // The rest of partial rounds.
         for offset in 0..8 {
@@ -144,20 +145,20 @@ impl SeptidonChip {
                 .collect::<Vec<_>>();
             state = self
                 .partial_round_chip
-                .assign(region, offset, &round_constants, state)?;
+                .assign(region, offset + begin_offset, &round_constants, state)?;
         }
 
         // The second half of full rounds.
         for offset in 4..8 {
             state =
                 self.full_round_chip
-                    .assign(region, offset, round_constant(offset + 57), state)?;
+                    .assign(region, offset + begin_offset, round_constant(offset + 57), state)?;
         }
 
         // Put the final state into its place.
         let final_offset = 7;
         self.transition_chip
-            .assign_final_state(region, final_offset, state)?;
+            .assign_final_state(region, final_offset + begin_offset, state)?;
 
         Ok(state)
     }

--- a/src/poseidon/septidon/septidon_chip.rs
+++ b/src/poseidon/septidon/septidon_chip.rs
@@ -124,7 +124,7 @@ impl SeptidonChip {
         initial_state: [Value<F>; 3],
         begin_offset: usize,
     ) -> Result<[Value<F>; 3], Error> {
-        self.control_chip.assign(region, begin_offset)?;
+        self.control_chip.assign_with_offset(region, begin_offset)?;
 
         let mut state = initial_state;
 

--- a/src/poseidon/septidon/septidon_chip.rs
+++ b/src/poseidon/septidon/septidon_chip.rs
@@ -117,7 +117,7 @@ impl SeptidonChip {
         self.assign_permutation_with_offset(region, initial_state, 0)
     }
 
-    /// Assign the witness of a permutation into the existen region.
+    /// Assign the witness of a permutation into the existent region.
     pub fn assign_permutation_with_offset<F: CachedConstants>(
         &self,
         region: &mut Region<'_, F>,

--- a/src/poseidon/septidon/septidon_chip.rs
+++ b/src/poseidon/septidon/septidon_chip.rs
@@ -112,8 +112,13 @@ impl SeptidonChip {
         })
     }
 
-    /// Assign the witness of a permutation into the given region.
-    pub fn assign_permutation<F: CachedConstants>(
+    /// Assign the witness of a permutation into the new region.
+    pub fn assign_permutation<F: CachedConstants>(&self, region: &mut Region<'_, F>, initial_state: [Value<F>; 3]) -> Result<[Value<F>; 3], Error> {
+        self.assign_permutation_with_offset(region, initial_state, 0)
+    }
+
+    /// Assign the witness of a permutation into the existen region.
+    pub fn assign_permutation_with_offset<F: CachedConstants>(
         &self,
         region: &mut Region<'_, F>,
         initial_state: [Value<F>; 3],

--- a/src/poseidon/septidon/tests.rs
+++ b/src/poseidon/septidon/tests.rs
@@ -52,7 +52,7 @@ impl Circuit<F> for TestCircuit {
 
             let final_state = layouter.assign_region(
                 || "SeptidonChip",
-                |mut region: Region<'_, F>| config.assign_permutation(&mut region, initial_state),
+                |mut region: Region<'_, F>| config.assign_permutation(&mut region, initial_state, 0),
             )?;
 
             let got = format!("{:?}", unwrap_value(join_values(final_state)));

--- a/src/poseidon/septidon/tests.rs
+++ b/src/poseidon/septidon/tests.rs
@@ -52,7 +52,7 @@ impl Circuit<F> for TestCircuit {
 
             let final_state = layouter.assign_region(
                 || "SeptidonChip",
-                |mut region: Region<'_, F>| config.assign_permutation(&mut region, initial_state, 0),
+                |mut region: Region<'_, F>| config.assign_permutation(&mut region, initial_state),
             )?;
 
             let got = format!("{:?}", unwrap_value(join_values(final_state)));

--- a/tests/hash_proving.rs
+++ b/tests/hash_proving.rs
@@ -35,7 +35,8 @@ impl Circuit<Fp> for TestCircuit {
 
     fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
         let hash_tbl = [0; 5].map(|_| meta.advice_column());
-        SpongeConfig::configure_sub(meta, hash_tbl, DEFAULT_STEP)
+        let q_enable = meta.fixed_column();
+        SpongeConfig::configure_sub(meta, (q_enable, hash_tbl), DEFAULT_STEP)
     }
 
     fn synthesize(


### PR DESCRIPTION
See #23 
===
### Bechmarking

For each phase (in AMD EPYC 7702 64-Core Processor x 128 threads):

before
```
ASSIGNMENT_TYPE: default Elapsed: 22.257506277s
```

after:
```
[2023-06-16T06:58:10Z INFO  poseidon_circuit::hash] hash table parallel version took 445.565348ms
[2023-06-16T07:03:29Z INFO  poseidon_circuit::hash] final state took 110.563839ms
```
around 556ms
