### PR TITLE
fix: parallel-syn domain spec, modify env variable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,15 @@ rand = "0.8"
 halo2_proofs = { git = "https://github.com/scroll-tech/halo2.git", branch = "develop" }
 
 [features]
-default = ["halo2_proofs/parallel_syn","short"]
+default = ["halo2_proofs/parallel_syn", "short"]
 # Use an implementation using fewer rows (8) per permutation.
 short = []
 # printout the layout of circuits for demo and some unittests
 print_layout = ["halo2_proofs/dev-graph"]
 legacy = []
+# "halo2_proofs/parallel_syn" is turned on by default for compilation
+# "parallel_syn" can be turned on/off via `zkevm-circuits`
+parallel_syn = ["halo2_proofs/parallel_syn"]
 
 [dev-dependencies]
 rand = "0.8"

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1226,7 +1226,7 @@ mod tests {
     #[test]
     #[cfg(feature = "parallel_syn")]
     fn poseidon_parallel_synthesis() {
-        // cargo test --release --package poseidon-circuit --lib hash::tests::poseidon_parallel_synthesis --features short,parallel_syncar
+        // cargo test --release --package poseidon-circuit --lib hash::tests::poseidon_parallel_synthesis --features short,parallel_syn
         poseidon_parallel_synthesis_impl::<Pow5Chip<Fr, 3, 2>>();
         poseidon_parallel_synthesis_impl::<SeptidonChip>();
     }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -682,7 +682,7 @@ where
             let control_as_flag = F::from_u128(control as u128 * HASHABLE_DOMAIN_SPEC);
 
             if is_new_sponge {
-                state[0] = control_as_flag;
+                state[0] = control_as_flag + domain;
                 process_start = offset;
             }
 


### PR DESCRIPTION
---
1st commit: add the missing domain in parallel-syn code logic

`state[0] = control_as_flag;`
to
`state[0] = control_as_flag + domain;`

---

2nd commit

- make `parallel_syn` as a common feature flag, which can be turned on/off via `zkevm-circuits`
- can be temporarily turned off by setting the env variable `CIRCUIT_ASSIGNMENT_TYPE=serial`

---